### PR TITLE
Added scroll to list only and not entire page

### DIFF
--- a/modules/flok/src/pages/DestinationsListPage.tsx
+++ b/modules/flok/src/pages/DestinationsListPage.tsx
@@ -35,6 +35,14 @@ import {
 } from "../utils/lodgingUtils"
 
 let useStyles = makeStyles((theme) => ({
+  bodyContainer: {
+    height: "100%",
+    overflow: "hidden",
+  },
+  listContainer: {
+    overflowY: "auto",
+    height: "100%",
+  },
   filterSection: {
     display: "flex",
     flexDirection: "column",
@@ -161,7 +169,7 @@ function DestinationsListPage(props: DestinationsListPageProps) {
               subheader="Finding the right destination is the first step to a planning a great retreat!"
               retreat={retreat !== ResourceNotFound ? retreat : undefined}
             />
-            <Grid container>
+            <Grid container className={classes.bodyContainer}>
               <Grid item xs={4}>
                 <Hidden smDown>
                   <div className={classes.filterSection}>
@@ -179,7 +187,7 @@ function DestinationsListPage(props: DestinationsListPageProps) {
                   </div>
                 </Hidden>
               </Grid>
-              <Grid item xs={12} md={8}>
+              <Grid item xs={12} md={8} className={classes.listContainer}>
                 <AppLodgingList>
                   {[
                     ...selectedDestinationIds

--- a/modules/flok/src/pages/HotelsListPage.tsx
+++ b/modules/flok/src/pages/HotelsListPage.tsx
@@ -44,6 +44,14 @@ import {
 } from "../utils/lodgingUtils"
 
 let useStyles = makeStyles((theme) => ({
+  bodyContainer: {
+    height: "100%",
+    overflow: "hidden",
+  },
+  listContainer: {
+    overflowY: "auto",
+    height: "100%",
+  },
   ctaSection: {
     display: "flex",
     flexDirection: "row",
@@ -250,7 +258,7 @@ function HotelsListPage(props: HotelsListPageProps) {
               retreat && retreat !== ResourceNotFound ? retreat : undefined
             }
           />
-          <Grid container>
+          <Grid container className={classes.bodyContainer}>
             <Grid item xs={4}>
               <Hidden smDown>
                 <div className={classes.filterSection}>
@@ -284,7 +292,7 @@ function HotelsListPage(props: HotelsListPageProps) {
                 </div>
               </Hidden>
             </Grid>
-            <Grid item xs={12} md={8}>
+            <Grid item xs={12} md={8} className={classes.listContainer}>
               <AppLodgingList onReachEnd={onReachEnd}>
                 {[
                   ...selectedHotelIds


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-

##### Description
Only the list scrolls now keeping header and filters in same place

##### Demo
