### PR TITLE
added tabs to flights and attendees admin side to update flights trav…

### DIFF
--- a/modules/flok-admin/src/components/retreats/AttendeesRegistrationFormIdForm.tsx
+++ b/modules/flok-admin/src/components/retreats/AttendeesRegistrationFormIdForm.tsx
@@ -1,0 +1,108 @@
+import {
+  Button,
+  makeStyles,
+  TextField,
+  TextFieldProps,
+  Typography,
+} from "@material-ui/core"
+import {useFormik} from "formik"
+import _ from "lodash"
+import {useDispatch} from "react-redux"
+import * as yup from "yup"
+import {patchRetreatDetails} from "../../store/actions/admin"
+import {getTextFieldErrorProps, useRetreat} from "../../utils"
+
+let useStyles = makeStyles((theme) => ({
+  body: {
+    flex: "1 1 auto",
+    width: "100%",
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(4),
+    paddingLeft: theme.spacing(4),
+    paddingRight: theme.spacing(4),
+    display: "flex",
+    flexDirection: "column",
+  },
+  header: {
+    width: "100%",
+    marginBottom: theme.spacing(1),
+  },
+  footer: {
+    paddingTop: theme.spacing(1),
+  },
+
+  root: {
+    borderRadius: theme.shape.borderRadius,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    backgroundColor: theme.palette.common.white,
+    display: "flex",
+    flexWrap: "wrap",
+    marginTop: theme.spacing(1),
+    marginLeft: theme.spacing(10),
+    marginRight: theme.spacing(10),
+    "& > *:not(:first-child)": {
+      marginTop: theme.spacing(1),
+    },
+  },
+  textField: {
+    marginBottom: theme.spacing(1.25),
+  },
+}))
+
+function AttendeesRegistrationFormIdForm(props: {retreatId: number}) {
+  const {retreatId} = props
+  let classes = useStyles(props)
+  let dispatch = useDispatch()
+
+  // Get retreat data
+  let [retreat] = useRetreat(retreatId)
+
+  let formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      attendees_registration_form_id:
+        retreat?.attendees_registration_form_id ?? "",
+    },
+    validationSchema: yup.object({
+      attendees_registration_form_id: yup.string(),
+    }),
+    onSubmit: (values) => {
+      retreat && dispatch(patchRetreatDetails(retreat.id, values))
+    },
+  })
+  const commonTextFieldProps: TextFieldProps = {
+    onChange: formik.handleChange,
+    InputLabelProps: {shrink: true},
+    fullWidth: true,
+    className: classes.textField,
+  }
+  return (
+    <form className={classes.root} onSubmit={formik.handleSubmit}>
+      <Typography className={classes.header} variant="h4">
+        Attendees Registration Google Form Id
+      </Typography>
+      <TextField
+        {...commonTextFieldProps}
+        id="attendees_registration_form_id"
+        {...getTextFieldErrorProps(formik, "attendees_registration_form_id")}
+        value={formik.values.attendees_registration_form_id}
+        label=" Attendees Registration Form Id"
+      />
+      <div className={classes.footer}>
+        <Button
+          variant="contained"
+          color="primary"
+          type="submit"
+          disabled={
+            _.isEqual(formik.initialValues, formik.values) || !formik.isValid
+          }>
+          Save State
+        </Button>
+      </div>
+    </form>
+  )
+}
+export default AttendeesRegistrationFormIdForm

--- a/modules/flok-admin/src/components/retreats/AttendeesRegistrationFormIdForm.tsx
+++ b/modules/flok-admin/src/components/retreats/AttendeesRegistrationFormIdForm.tsx
@@ -14,24 +14,6 @@ import {patchRetreatDetails} from "../../store/actions/admin"
 import {getTextFieldErrorProps, useRetreat} from "../../utils"
 
 let useStyles = makeStyles((theme) => ({
-  body: {
-    flex: "1 1 auto",
-    width: "100%",
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(4),
-    paddingLeft: theme.spacing(4),
-    paddingRight: theme.spacing(4),
-    display: "flex",
-    flexDirection: "column",
-  },
-  header: {
-    width: "100%",
-    marginBottom: theme.spacing(1),
-  },
-  footer: {
-    paddingTop: theme.spacing(1),
-  },
-
   root: {
     borderRadius: theme.shape.borderRadius,
     paddingTop: theme.spacing(1),
@@ -42,15 +24,21 @@ let useStyles = makeStyles((theme) => ({
     display: "flex",
     flexWrap: "wrap",
     marginTop: theme.spacing(1),
-    marginLeft: theme.spacing(10),
-    marginRight: theme.spacing(10),
     "& > *:not(:first-child)": {
       marginTop: theme.spacing(1),
     },
+    maxWidth: theme.breakpoints.values.lg,
+    marginLeft: "auto",
+    marginRight: "auto",
   },
-  textField: {
-    marginBottom: theme.spacing(1.25),
+  header: {
+    width: "100%",
+    marginBottom: theme.spacing(1),
   },
+  footer: {
+    paddingTop: theme.spacing(1),
+  },
+  textField: {},
 }))
 
 function AttendeesRegistrationFormIdForm(props: {retreatId: number}) {

--- a/modules/flok-admin/src/components/retreats/AttendeesRegistrationFormIdForm.tsx
+++ b/modules/flok-admin/src/components/retreats/AttendeesRegistrationFormIdForm.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Link,
   makeStyles,
   TextField,
   TextFieldProps,
@@ -90,6 +91,19 @@ function AttendeesRegistrationFormIdForm(props: {retreatId: number}) {
         {...getTextFieldErrorProps(formik, "attendees_registration_form_id")}
         value={formik.values.attendees_registration_form_id}
         label=" Attendees Registration Form Id"
+        helperText={
+          formik.values.attendees_registration_form_id ? (
+            <>
+              Form link:{" "}
+              <Link
+                href={`https://docs.google.com/forms/d/e/${formik.values.attendees_registration_form_id}/viewform`}
+                target="_blank">
+                https://docs.google.com/forms/d/e/
+                {formik.values.attendees_registration_form_id}/viewform
+              </Link>
+            </>
+          ) : undefined
+        }
       />
       <div className={classes.footer}>
         <Button

--- a/modules/flok-admin/src/components/retreats/FlightsTravelPoliciesForm.tsx
+++ b/modules/flok-admin/src/components/retreats/FlightsTravelPoliciesForm.tsx
@@ -1,0 +1,110 @@
+import {
+  Button,
+  makeStyles,
+  TextField,
+  TextFieldProps,
+  Typography,
+} from "@material-ui/core"
+import {useFormik} from "formik"
+import _ from "lodash"
+import {useDispatch} from "react-redux"
+import * as yup from "yup"
+import {patchRetreatDetails} from "../../store/actions/admin"
+import {getTextFieldErrorProps, useRetreat} from "../../utils"
+
+let useStyles = makeStyles((theme) => ({
+  body: {
+    flex: "1 1 auto",
+    width: "100%",
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(4),
+    paddingLeft: theme.spacing(4),
+    paddingRight: theme.spacing(4),
+    display: "flex",
+    flexDirection: "column",
+  },
+  header: {
+    width: "100%",
+    marginBottom: theme.spacing(1),
+  },
+  footer: {
+    paddingTop: theme.spacing(1),
+  },
+
+  root: {
+    borderRadius: theme.shape.borderRadius,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    backgroundColor: theme.palette.common.white,
+    display: "flex",
+    flexWrap: "wrap",
+    marginTop: theme.spacing(1),
+    marginLeft: theme.spacing(10),
+    marginRight: theme.spacing(10),
+    "& > *:not(:first-child)": {
+      marginTop: theme.spacing(1),
+    },
+  },
+  textField: {
+    marginBottom: theme.spacing(1.25),
+  },
+}))
+
+function FlightsTravelPoliciesForm(props: {retreatId: number}) {
+  const {retreatId} = props
+  let classes = useStyles(props)
+  let dispatch = useDispatch()
+
+  // Get retreat data
+  let [retreat] = useRetreat(retreatId)
+
+  let formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      flights_travel_policies_link: retreat?.flights_travel_policies_link ?? "",
+    },
+    validationSchema: yup.object({
+      flights_travel_policies_link: yup
+        .string()
+        .url("Please enter a valid URL"),
+    }),
+    onSubmit: (values) => {
+      retreat && dispatch(patchRetreatDetails(retreat.id, values))
+    },
+  })
+  const commonTextFieldProps: TextFieldProps = {
+    onChange: formik.handleChange,
+    InputLabelProps: {shrink: true},
+    fullWidth: true,
+    className: classes.textField,
+  }
+  return (
+    <form className={classes.root} onSubmit={formik.handleSubmit}>
+      <Typography className={classes.header} variant="h4">
+        Retreat Flights Travel Policy Link
+      </Typography>
+      <TextField
+        {...commonTextFieldProps}
+        id="flights_travel_policies_link"
+        {...getTextFieldErrorProps(formik, "flights_travel_policies_link")}
+        value={formik.values.flights_travel_policies_link}
+        label="Retreat Flights Travel Policy Link"
+      />
+
+      <div className={classes.footer}>
+        <Button
+          variant="contained"
+          color="primary"
+          type="submit"
+          disabled={
+            _.isEqual(formik.initialValues, formik.values) || !formik.isValid
+          }>
+          Save State
+        </Button>
+      </div>
+    </form>
+  )
+}
+export default FlightsTravelPoliciesForm

--- a/modules/flok-admin/src/components/retreats/FlightsTravelPoliciesForm.tsx
+++ b/modules/flok-admin/src/components/retreats/FlightsTravelPoliciesForm.tsx
@@ -13,24 +13,6 @@ import {patchRetreatDetails} from "../../store/actions/admin"
 import {getTextFieldErrorProps, useRetreat} from "../../utils"
 
 let useStyles = makeStyles((theme) => ({
-  body: {
-    flex: "1 1 auto",
-    width: "100%",
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(4),
-    paddingLeft: theme.spacing(4),
-    paddingRight: theme.spacing(4),
-    display: "flex",
-    flexDirection: "column",
-  },
-  header: {
-    width: "100%",
-    marginBottom: theme.spacing(1),
-  },
-  footer: {
-    paddingTop: theme.spacing(1),
-  },
-
   root: {
     borderRadius: theme.shape.borderRadius,
     paddingTop: theme.spacing(1),
@@ -41,15 +23,21 @@ let useStyles = makeStyles((theme) => ({
     display: "flex",
     flexWrap: "wrap",
     marginTop: theme.spacing(1),
-    marginLeft: theme.spacing(10),
-    marginRight: theme.spacing(10),
     "& > *:not(:first-child)": {
       marginTop: theme.spacing(1),
     },
+    maxWidth: theme.breakpoints.values.lg,
+    marginLeft: "auto",
+    marginRight: "auto",
   },
-  textField: {
-    marginBottom: theme.spacing(1.25),
+  header: {
+    width: "100%",
+    marginBottom: theme.spacing(1),
   },
+  footer: {
+    paddingTop: theme.spacing(1),
+  },
+  textField: {},
 }))
 
 function FlightsTravelPoliciesForm(props: {retreatId: number}) {

--- a/modules/flok-admin/src/models/index.tsx
+++ b/modules/flok-admin/src/models/index.tsx
@@ -48,10 +48,12 @@ export type AdminRetreatModel = {
   // Retreat data related to itinerary
   itinerary_state?: RetreatItineraryState
 
-  //Andrew added for task
-
+  // Retreat links
   itinerary_first_draft_link?: string
   itinerary_final_draft_link?: string
+
+  flights_travel_policies_link: string | null
+  attendees_registration_form_id: string | null
 }
 
 export type AdminRetreatUpdateModel = Pick<

--- a/modules/flok-admin/src/pages/RetreatAttendeesPage.tsx
+++ b/modules/flok-admin/src/pages/RetreatAttendeesPage.tsx
@@ -5,24 +5,28 @@ import {
   Dialog,
   Link,
   makeStyles,
+  Tab,
+  Tabs,
 } from "@material-ui/core"
 import {push} from "connected-react-router"
 import _ from "lodash"
-import {useState} from "react"
+import {useEffect, useState} from "react"
 import {useDispatch} from "react-redux"
 import {
   Link as ReactRouterLink,
   RouteComponentProps,
   withRouter,
 } from "react-router-dom"
+import AppTabPanel from "../components/base/AppTabPanel"
 import AppTypography from "../components/base/AppTypography"
 import PageBase from "../components/page/PageBase"
+import AttendeesRegistrationFormIdForm from "../components/retreats/AttendeesRegistrationFormIdForm"
 import NewRetreatAttendeeForm from "../components/retreats/NewRetreatAttendeeForm"
 import RetreatAttendeesTable from "../components/retreats/RetreatAttendeesTable"
 import RetreatStateTitle from "../components/retreats/RetreatStateTitle"
 import {AppRoutes} from "../Stack"
 import {theme} from "../theme"
-import {useRetreat, useRetreatAttendees} from "../utils"
+import {useQuery, useRetreat, useRetreatAttendees} from "../utils"
 
 let useStyles = makeStyles((theme) => ({
   body: {
@@ -35,6 +39,10 @@ let useStyles = makeStyles((theme) => ({
     display: "flex",
     flexDirection: "column",
   },
+  tabBody: {
+    flex: "1 1 auto",
+    minHeight: 0,
+  },
 }))
 
 type RetreatAttendeesPageProps = RouteComponentProps<{
@@ -45,6 +53,12 @@ function RetreatAttendeesPage(props: RetreatAttendeesPageProps) {
   let classes = useStyles(props)
   let dispatch = useDispatch()
   let retreatId = parseInt(props.match.params.retreatId) || -1 // -1 for an id that will always return 404
+  let [tabQuery, setTabQuery] = useQuery("tab")
+  let [tabValue, setTabValue] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    const TABS = ["other info", "attendees"]
+    setTabValue(tabQuery && TABS.includes(tabQuery) ? tabQuery : "attendees")
+  }, [tabQuery, setTabValue])
 
   // Get retreat data
   let [retreat] = useRetreat(retreatId)
@@ -93,25 +107,54 @@ function RetreatAttendeesPage(props: RetreatAttendeesPageProps) {
             />
           </Dialog>
         </Box>
-        <RetreatAttendeesTable
-          rows={
-            retreatAttendees
-              ? retreatAttendees.map((a) =>
-                  _.pick(a, ["id", "name", "email_address", "info_status"])
-                )
-              : []
-          }
-          onSelect={(id: number) => {
-            dispatch(
-              push(
-                AppRoutes.getPath("RetreatAttendeePage", {
-                  retreatId: retreatId.toString(),
-                  attendeeId: id.toString(),
-                })
-              )
-            )
-          }}
-        />
+
+        {retreat && (
+          <>
+            <Tabs
+              value={tabValue}
+              onChange={(e, newVal) =>
+                setTabQuery(newVal === "attendees" ? null : newVal)
+              }
+              variant="fullWidth"
+              indicatorColor="primary">
+              <Tab value="attendees" label="Attendees" />
+              <Tab value="other info" label="Other info" />
+            </Tabs>
+            <AppTabPanel
+              show={tabValue === "attendees"}
+              className={classes.tabBody}>
+              <RetreatAttendeesTable
+                rows={
+                  retreatAttendees
+                    ? retreatAttendees.map((a) =>
+                        _.pick(a, [
+                          "id",
+                          "name",
+                          "email_address",
+                          "info_status",
+                        ])
+                      )
+                    : []
+                }
+                onSelect={(id: number) => {
+                  dispatch(
+                    push(
+                      AppRoutes.getPath("RetreatAttendeePage", {
+                        retreatId: retreatId.toString(),
+                        attendeeId: id.toString(),
+                      })
+                    )
+                  )
+                }}
+              />
+            </AppTabPanel>
+            <AppTabPanel
+              show={tabValue === "other info"}
+              className={classes.tabBody}>
+              <AttendeesRegistrationFormIdForm retreatId={retreat.id} />
+            </AppTabPanel>
+          </>
+        )}
       </div>
     </PageBase>
   )

--- a/modules/flok-admin/src/pages/RetreatAttendeesPage.tsx
+++ b/modules/flok-admin/src/pages/RetreatAttendeesPage.tsx
@@ -56,7 +56,7 @@ function RetreatAttendeesPage(props: RetreatAttendeesPageProps) {
   let [tabQuery, setTabQuery] = useQuery("tab")
   let [tabValue, setTabValue] = useState<string | undefined>(undefined)
   useEffect(() => {
-    const TABS = ["other info", "attendees"]
+    const TABS = ["info", "attendees"]
     setTabValue(tabQuery && TABS.includes(tabQuery) ? tabQuery : "attendees")
   }, [tabQuery, setTabValue])
 
@@ -118,7 +118,7 @@ function RetreatAttendeesPage(props: RetreatAttendeesPageProps) {
               variant="fullWidth"
               indicatorColor="primary">
               <Tab value="attendees" label="Attendees" />
-              <Tab value="other info" label="Other info" />
+              <Tab value="info" label="Other info" />
             </Tabs>
             <AppTabPanel
               show={tabValue === "attendees"}
@@ -148,9 +148,7 @@ function RetreatAttendeesPage(props: RetreatAttendeesPageProps) {
                 }}
               />
             </AppTabPanel>
-            <AppTabPanel
-              show={tabValue === "other info"}
-              className={classes.tabBody}>
+            <AppTabPanel show={tabValue === "info"} className={classes.tabBody}>
               <AttendeesRegistrationFormIdForm retreatId={retreat.id} />
             </AppTabPanel>
           </>

--- a/modules/flok-admin/src/pages/RetreatFlightsPage.tsx
+++ b/modules/flok-admin/src/pages/RetreatFlightsPage.tsx
@@ -39,7 +39,7 @@ function RetreatFlightsPage(props: RetreatFlightsPageProps) {
   let [tabQuery, setTabQuery] = useQuery("tab")
   let [tabValue, setTabValue] = useState<string | undefined>(undefined)
   useEffect(() => {
-    const TABS = ["other info", "flights"]
+    const TABS = ["info", "flights"]
     setTabValue(tabQuery && TABS.includes(tabQuery) ? tabQuery : "flights")
   }, [tabQuery, setTabValue])
 
@@ -77,7 +77,7 @@ function RetreatFlightsPage(props: RetreatFlightsPageProps) {
               variant="fullWidth"
               indicatorColor="primary">
               <Tab value="flights" label="Flights" />
-              <Tab value="other info" label="Other info" />
+              <Tab value="info" label="Other info" />
             </Tabs>
             <AppTabPanel
               show={tabValue === "flights"}
@@ -87,9 +87,7 @@ function RetreatFlightsPage(props: RetreatFlightsPageProps) {
                 retreatId={retreatId}
               />
             </AppTabPanel>
-            <AppTabPanel
-              show={tabValue === "other info"}
-              className={classes.tabBody}>
+            <AppTabPanel show={tabValue === "info"} className={classes.tabBody}>
               <FlightsTravelPoliciesForm retreatId={retreat.id} />
             </AppTabPanel>
           </>


### PR DESCRIPTION
…el policies link and attendees registration form id

#### Linear 🎫 
https://linear.app/flok/issue/FLO-280

##### Description
added tabs to the admin side flights and attendees pages that allow users to update the retreat flights_travel_policies_link
as well as the attendees_registration_form_id
##### Demo
<img width="1512" alt="Screen Shot 2022-04-06 at 1 32 23 PM" src="https://user
<img width="1512" alt="Screen Shot 2022-04-06 at 1 32 41 PM" src="https://user-images.githubusercontent.com/41205015/162036288-2a38279e-39de-4157-84ce-5b35e7a693bc.png">

<img width="1512" alt="Screen Shot 2022-04-06 at 1 32 29 PM" src="https://user-images.githubusercontent.com/41205015/162036273-7334e030-b5f5-42b4-8ad4-c750626d4cc3.png">
-images.githubusercontent.com/41205015/162036242-0b18876f-15ee-47c6-873c-0eaeaa5179b3.png">
<img width="1512" alt="Screen Shot 2022-04-06 at 1 32 47 PM" src="https://user-images.githubusercontent.com/41205015/162036314-f7d65b8e-b578-472d-9a3b-ea8679201297.png">


