### PR TITLE
admin users cleanup

### DIFF
--- a/modules/flok-admin/src/components/users/NewUserModal.tsx
+++ b/modules/flok-admin/src/components/users/NewUserModal.tsx
@@ -23,17 +23,24 @@ let useStyles = makeStyles((theme) => ({
   },
 }))
 
-type NewUserModalProps = {open: boolean; onClose: (submitted: boolean) => void}
+type NewUserModalProps = {
+  open: boolean
+  onClose: (submitted: boolean) => void
+  autofill?: number
+}
 export default function NewUserModal(props: NewUserModalProps) {
   let classes = useStyles(props)
   let dispatch = useDispatch()
+  let retreatList = useRetreatList()
   let formik = useFormik({
     enableReinitialize: true,
     initialValues: {
       email: null,
       firstName: null,
       lastName: null,
-      retreats: [] as AdminRetreatListModel[],
+      retreats: (props.autofill !== undefined && props.autofill !== -1
+        ? [retreatList.find((val) => val.id === props.autofill)]
+        : []) as AdminRetreatListModel[],
     },
     onSubmit: (values) => {
       dispatch(
@@ -47,8 +54,6 @@ export default function NewUserModal(props: NewUserModalProps) {
       props.onClose(true)
     },
   })
-
-  let retreatList = useRetreatList()
 
   const commonTextFieldProps: TextFieldProps = {
     onChange: formik.handleChange,

--- a/modules/flok-admin/src/components/users/NewUserModal.tsx
+++ b/modules/flok-admin/src/components/users/NewUserModal.tsx
@@ -38,7 +38,7 @@ export default function NewUserModal(props: NewUserModalProps) {
       email: null,
       firstName: null,
       lastName: null,
-      retreats: (props.autofill !== undefined && props.autofill !== -1
+      retreats: (props.autofill !== undefined
         ? [retreatList.find((val) => val.id === props.autofill)]
         : []) as AdminRetreatListModel[],
     },

--- a/modules/flok-admin/src/components/users/SearchUserModal.tsx
+++ b/modules/flok-admin/src/components/users/SearchUserModal.tsx
@@ -4,13 +4,13 @@ import {
   ListItemText,
   Modal,
   Paper,
-  TextField,
+  TextField
 } from "@material-ui/core"
-import {Autocomplete} from "@material-ui/lab"
+import { Autocomplete } from "@material-ui/lab"
 import _ from "lodash"
-import React, {useState} from "react"
-import {User} from "../../models"
-import {useRetreatUsers} from "../../utils"
+import React, { useState } from "react"
+import { User } from "../../models"
+import { useRetreatUsers } from "../../utils"
 import AppTypography from "../base/AppTypography"
 
 type SearchUserModalProps = {
@@ -20,7 +20,7 @@ type SearchUserModalProps = {
 }
 export default function SearchUserModal(props: SearchUserModalProps) {
   let [input, setInput] = useState("")
-  let [users, loading] = useRetreatUsers(-1)
+  let [users, loading] = useRetreatUsers()
   return (
     <Modal open={props.open} onClose={props.onClose}>
       <Box

--- a/modules/flok-admin/src/components/users/SearchUserModal.tsx
+++ b/modules/flok-admin/src/components/users/SearchUserModal.tsx
@@ -1,0 +1,100 @@
+import {
+  Box,
+  ListItem,
+  ListItemText,
+  Modal,
+  Paper,
+  TextField,
+} from "@material-ui/core"
+import {Autocomplete} from "@material-ui/lab"
+import _ from "lodash"
+import React, {useState} from "react"
+import {User} from "../../models"
+import {useRetreatUsers} from "../../utils"
+import AppTypography from "../base/AppTypography"
+
+type SearchUserModalProps = {
+  onSubmit: (user: User) => void
+  open: boolean
+  onClose: () => void
+}
+export default function SearchUserModal(props: SearchUserModalProps) {
+  let [input, setInput] = useState("")
+  let [users, loading] = useRetreatUsers(-1)
+  return (
+    <Modal open={props.open} onClose={props.onClose}>
+      <Box
+        maxWidth={500}
+        minWidth={400}
+        position="fixed"
+        top="50%"
+        left="50%"
+        style={{
+          transform: "translate(-50%, -50%)",
+        }}>
+        <Paper>
+          <Box paddingY={4} paddingX={2} display="flex" flexDirection="column">
+            <AppTypography variant="body1" fontWeight="bold" paragraph>
+              Select User
+            </AppTypography>
+            <Box display="flex" paddingTop={2}>
+              <Autocomplete
+                loading={loading}
+                clearOnBlur={false}
+                fullWidth
+                onChange={(e, val) => val && props.onSubmit(val)}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    placeholder="Search by user email"
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                  />
+                )}
+                options={_.values(users)}
+                getOptionLabel={(opt) => opt.email}
+                filterOptions={(options, state) => {
+                  return options
+                    .filter((val) =>
+                      val.email.toLowerCase().includes(input.toLowerCase())
+                    )
+                    .sort((a, b) => {
+                      let matchA = a.email
+                        .toLowerCase()
+                        .indexOf(input.toLowerCase())
+                      let matchB = b.email
+                        .toLowerCase()
+                        .indexOf(input.toLowerCase())
+                      return matchA > matchB ? 1 : matchA === matchB ? 0 : -1
+                    })
+                }}
+                renderOption={(option) => {
+                  let matchStart = option.email
+                    .toLowerCase()
+                    .indexOf(input.toLowerCase())
+                  let pre = option.email.slice(0, matchStart)
+                  let match = option.email.slice(
+                    matchStart,
+                    matchStart + input.length
+                  )
+                  let post = option.email.slice(matchStart + input.length)
+                  return (
+                    <ListItem>
+                      <ListItemText>
+                        {pre}
+                        <strong>{match}</strong>
+                        {post}
+                        {option.last_name && ", " + option.last_name}
+                        {option.first_name && ", " + option.first_name}
+                      </ListItemText>
+                    </ListItem>
+                  )
+                }}
+              />
+            </Box>
+          </Box>
+        </Paper>
+      </Box>
+    </Modal>
+  )
+}

--- a/modules/flok-admin/src/components/users/UsersTable.tsx
+++ b/modules/flok-admin/src/components/users/UsersTable.tsx
@@ -41,7 +41,7 @@ export default function UsersTable(props: UsersTableProps) {
   let classes = useStyles(props)
   let dispatch = useDispatch()
 
-  let [users, loading] = useRetreatUsers(props.retreatId ?? -1)
+  let [users, loading] = useRetreatUsers(props.retreatId)
 
   let [activeUser, setActiveUser] = useState<User | undefined>(undefined)
   let [newUserOpen, setNewUserOpen] = useState(false)
@@ -60,21 +60,8 @@ export default function UsersTable(props: UsersTableProps) {
     let rowIdAsString = params.getValue(params.id, "id")?.toString()
     let rowId = rowIdAsString ? parseInt(rowIdAsString) : null
     if (rowId != null && !isNaN(rowId)) {
-      setActiveUser(users[rowId])
-      // if (retreatId !== -1) {
-      //   dispatch(
-      //     push(
-      //       AppRoutes.getPath("RetreatUserPage", {
-      //         userId: rowId.toString(),
-      //         retreatId: retreatId.toString(),
-      //       })
-      //     )
-      //   )
-      // } else {
-      //   dispatch(
-      //     push(AppRoutes.getPath("UserPage", {userId: rowId.toString()}))
-      //   )
-      // }
+      setActiveUser((users ?? {})[rowId])
+      console.log(activeUser, users)
     } else {
       dispatch(enqueueSnackbar({message: "Something went wrong"}))
     }
@@ -86,7 +73,9 @@ export default function UsersTable(props: UsersTableProps) {
         user.id,
         user.first_name,
         user.last_name,
-        _.uniq(user.retreat_ids.concat([props.retreatId ?? -1]))
+        _.uniq(
+          user.retreat_ids.concat(props.retreatId ? [props.retreatId] : [])
+        )
       )
     )
     setAddUserOpen(false)

--- a/modules/flok-admin/src/components/users/UsersTable.tsx
+++ b/modules/flok-admin/src/components/users/UsersTable.tsx
@@ -11,6 +11,7 @@ import {useState} from "react"
 import {useDispatch} from "react-redux"
 import {User} from "../../models"
 import {enqueueSnackbar} from "../../notistack-lib/actions"
+import {patchUser} from "../../store/actions/admin"
 import {
   getDateFromString,
   getDateTimeString,
@@ -18,6 +19,7 @@ import {
 } from "../../utils"
 import AppLoadingScreen from "../base/AppLoadingScreen"
 import NewUserModal from "../users/NewUserModal"
+import SearchUserModal from "./SearchUserModal"
 import UserInfoModal from "./UserInfoModal"
 
 let useStyles = makeStyles((theme) => ({
@@ -43,6 +45,7 @@ export default function UsersTable(props: UsersTableProps) {
 
   let [activeUser, setActiveUser] = useState<User | undefined>(undefined)
   let [newUserOpen, setNewUserOpen] = useState(false)
+  let [addUserOpen, setAddUserOpen] = useState(false)
 
   const createTableRows = (users: {[id: number]: User}) =>
     _.values(users).map((u) => ({
@@ -75,6 +78,18 @@ export default function UsersTable(props: UsersTableProps) {
     } else {
       dispatch(enqueueSnackbar({message: "Something went wrong"}))
     }
+  }
+
+  const handleAddUser = (user: User) => {
+    dispatch(
+      patchUser(
+        user.id,
+        user.first_name,
+        user.last_name,
+        _.uniq(user.retreat_ids.concat([props.retreatId ?? -1]))
+      )
+    )
+    setAddUserOpen(false)
   }
 
   const [sortModel, setSortModel] = useState<GridSortModel | undefined>([
@@ -140,6 +155,15 @@ export default function UsersTable(props: UsersTableProps) {
       ) : (
         <>
           <div className={classes.newUserRow}>
+            {props.retreatId && (
+              <Button
+                onClick={() => setAddUserOpen(true)}
+                variant="contained"
+                style={{marginRight: 6}}
+                color="primary">
+                Add existing user
+              </Button>
+            )}
             <Button
               onClick={() => setNewUserOpen(true)}
               variant="outlined"
@@ -165,6 +189,7 @@ export default function UsersTable(props: UsersTableProps) {
       )}
       <NewUserModal
         open={newUserOpen}
+        autofill={props.retreatId}
         onClose={(submitted) => setNewUserOpen(false)}
       />
       {activeUser && (
@@ -174,6 +199,11 @@ export default function UsersTable(props: UsersTableProps) {
           onClose={() => setActiveUser(undefined)}
         />
       )}
+      <SearchUserModal
+        onSubmit={(user) => handleAddUser(user)}
+        open={addUserOpen}
+        onClose={() => setAddUserOpen(false)}
+      />
     </>
   )
 }

--- a/modules/flok-admin/src/pages/UsersPage.tsx
+++ b/modules/flok-admin/src/pages/UsersPage.tsx
@@ -44,15 +44,15 @@ function UsersPage(props: UsersPageProps) {
 
   let retreatId = props.match.params.retreatId
     ? parseInt(props.match.params.retreatId)
-    : -1
+    : undefined
 
   let retreat = useSelector((state: RootState) =>
-    retreatId === -1
+    retreatId === undefined
       ? {company_name: ""}
       : state.admin.retreatsDetails[retreatId]
   )
   useEffect(() => {
-    if (retreatId !== -1 && retreat === undefined) {
+    if (retreatId !== undefined && retreat === undefined) {
       dispatch(getRetreatDetails(retreatId))
     }
   })
@@ -60,7 +60,7 @@ function UsersPage(props: UsersPageProps) {
   return (
     <PageBase>
       <div className={classes.body}>
-        {retreatId !== -1 && (
+        {retreatId !== undefined && (
           <Breadcrumbs aria-label="breadcrumb">
             <Link
               color="inherit"

--- a/modules/flok-admin/src/store/actions/admin.tsx
+++ b/modules/flok-admin/src/store/actions/admin.tsx
@@ -528,8 +528,10 @@ export function getHotelsSearch(search: string) {
 export const GET_USERS_REQUEST = "GET_USERS_REQUEST"
 export const GET_USERS_SUCCESS = "GET_USERS_SUCCESS"
 export const GET_USERS_FAILURE = "GET_USERS_FAILURE"
-export function getUsers(retreatId: number) {
-  let endpoint = `/v1.0/admin/users?retreat_id=${retreatId}`
+export function getUsers(retreatId?: number) {
+  let endpoint = retreatId
+    ? `/v1.0/admin/users?retreat_id=${retreatId}`
+    : `/v1.0/admin/users`
   return createApiAction({
     method: "GET",
     endpoint,

--- a/modules/flok-admin/src/store/reducers/admin.tsx
+++ b/modules/flok-admin/src/store/reducers/admin.tsx
@@ -319,29 +319,30 @@ export default function AdminReducer(
       }
     case POST_USER_SUCCESS:
     case PATCH_USER_SUCCESS:
-      payload = (action as unknown as ApiAction).payload as {
+      let thisPayload = (action as unknown as ApiAction).payload as {
         user: User
         login_token?: string
       }
-      if (payload.user.retreat_ids.length === 0) return state
       let newState = {
         ...state,
         usersByRetreat: {
           ...state.usersByRetreat,
           [-1]: {
             ...state.usersByRetreat[-1],
-            [payload.user.id]: payload.user,
-          },
-          [payload.user.retreat_ids[0]]: {
-            ...state.usersByRetreat[payload.user.retreat_ids[0]],
-            [payload.user.id]: payload.user,
+            [thisPayload.user.id]: thisPayload.user,
           },
         },
-      }
-      if (payload.login_token) {
+      } as AdminState
+      thisPayload.user.retreat_ids.forEach((id) => {
+        newState.usersByRetreat[id] = {
+          ...newState.usersByRetreat[id],
+          [thisPayload.user.id]: thisPayload.user,
+        }
+      })
+      if (thisPayload.login_token) {
         newState.userLoginTokens = {
           ...newState.userLoginTokens,
-          [payload.user.id]: payload.login_token,
+          [thisPayload.user.id]: thisPayload.login_token,
         }
       }
       return newState

--- a/modules/flok-admin/src/utils/index.tsx
+++ b/modules/flok-admin/src/utils/index.tsx
@@ -172,11 +172,11 @@ export function useHotelsBySearch(search: string) {
   return [results ? results : [], loading] as const
 }
 
-export function useRetreatUsers(retreatId: number) {
+export function useRetreatUsers(retreatId?: number | undefined) {
   let dispatch = useDispatch()
   let [loading, setLoading] = useState(false)
-  let users = useSelector(
-    (state: RootState) => state.admin.usersByRetreat[retreatId]
+  let users = useSelector((state: RootState) =>
+    retreatId ? state.admin.usersByRetreat[retreatId] : state.admin.allUsers
   )
   useEffect(() => {
     async function loadUsers() {


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-283

##### Description
Admin user changes:
- users table on users page now populating with new users
- new button/modal to add existing user to retreat from retreat users page:
- new user modal autofills with current retreat when possible
##### Demo
add existing user flow:
<img width="1174" alt="Screen Shot 2022-04-06 at 11 07 17 AM" src="https://user-images.githubusercontent.com/18358581/162040969-5bf4cd46-04d3-4830-8df1-b455524789e6.png">
<img width="1176" alt="Screen Shot 2022-04-06 at 11 07 35 AM" src="https://user-images.githubusercontent.com/18358581/162040985-b855cfa3-9dd4-46f4-9bc5-ef2b8646b734.png">

