### PR TITLE
add init tasks button

### DIFF
--- a/modules/flok-admin/src/components/tasks/InitTaskButton.tsx
+++ b/modules/flok-admin/src/components/tasks/InitTaskButton.tsx
@@ -1,0 +1,22 @@
+import {Button} from "@material-ui/core"
+import {useState} from "react"
+import {useDispatch} from "react-redux"
+import {addRetreatTasks} from "../../store/actions/admin"
+
+export default function InitTaskButton(props: {retreatId: number}) {
+  let [modalOpen, setModalOpen] = useState(false)
+  let [version, setVersion] = useState(0)
+  let [overwrite, setOverwrite] = useState(false)
+
+  let dispatch = useDispatch()
+
+  let onSubmit = () => {
+    dispatch(addRetreatTasks(props.retreatId, version, overwrite))
+  }
+
+  return (
+    <Button variant="contained" color="primary" onClick={onSubmit}>
+      Initialize Retreat Tasks
+    </Button>
+  )
+}

--- a/modules/flok-admin/src/pages/RetreatTasksPage.tsx
+++ b/modules/flok-admin/src/pages/RetreatTasksPage.tsx
@@ -9,6 +9,7 @@ import {
 import AppTypography from "../components/base/AppTypography"
 import PageBase from "../components/page/PageBase"
 import AppTodoList from "../components/retreats/RetreatTaskList"
+import InitTaskButton from "../components/tasks/InitTaskButton"
 import {AppRoutes} from "../Stack"
 import {RootState} from "../store"
 import {getRetreatDetails, getRetreatTasks} from "../store/actions/admin"
@@ -82,14 +83,18 @@ function RetreatTasksPage(props: RetreatTasksPageProps) {
           <AppTypography color="textPrimary">Tasks</AppTypography>
         </Breadcrumbs>
         <Typography variant="h1">{retreat?.company_name} - Tasks</Typography>
-        {tasks !== undefined ? (
+        {tasks !== undefined && tasks.length > 0 ? (
           <AppTodoList
             retreatId={retreatId}
             retreatToTasks={tasks}
             orderBadge={false}
             collapsed={false}
           />
-        ) : undefined}
+        ) : (
+          <div style={{width: "auto"}}>
+            <InitTaskButton retreatId={retreatId} />
+          </div>
+        )}
       </div>
     </PageBase>
   )

--- a/modules/flok-admin/src/store/actions/admin.tsx
+++ b/modules/flok-admin/src/store/actions/admin.tsx
@@ -701,3 +701,25 @@ export function getTask(task_id: number) {
     ],
   })
 }
+
+export const ADD_RETREAT_TASKS_REQUEST = "ADD_RETREAT_TASKS_REQUEST"
+export const ADD_RETREAT_TASKS_SUCCESS = "ADD_RETREAT_TASKS_SUCCESS"
+export const ADD_RETREAT_TASKS_FAILURE = "ADD_RETREAT_TASKS_FAILURE"
+
+export function addRetreatTasks(
+  retreat_id: number,
+  version: number,
+  overwrite: boolean
+) {
+  let endpoint = `/v1.0/admin/retreats/${retreat_id}/tasks`
+  return createApiAction({
+    endpoint,
+    method: "POST",
+    body: JSON.stringify({version, overwrite}),
+    types: [
+      {type: ADD_RETREAT_TASKS_REQUEST, meta: {retreatId: retreat_id}},
+      {type: ADD_RETREAT_TASKS_SUCCESS, meta: {retreatId: retreat_id}},
+      {type: ADD_RETREAT_TASKS_FAILURE, meta: {retreatId: retreat_id}},
+    ],
+  })
+}

--- a/modules/flok-admin/src/store/reducers/admin.tsx
+++ b/modules/flok-admin/src/store/reducers/admin.tsx
@@ -15,6 +15,7 @@ import {
   User,
 } from "../../models"
 import {
+  ADD_RETREAT_TASKS_SUCCESS,
   DELETE_RETREAT_ATTENDEES_SUCCESS,
   DELETE_RETREAT_HOTEL_PROPOSAL_SUCCESS,
   DELETE_SELECTED_HOTEL_SUCCESS,
@@ -309,6 +310,7 @@ export default function AdminReducer(
           [meta.retreatId]: payload.notes,
         },
       }
+    case ADD_RETREAT_TASKS_SUCCESS:
     case GET_RETREAT_TASKS_SUCCESS:
     case PATCH_RETREAT_TASK_SUCCESS:
       meta = (action as unknown as {meta: {retreatId: number}}).meta


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-286

##### Description
Adds button to initialize all tasks for a retreat, does not allow for versioning currently
https://github.com/Summ-Technologies/flok-backend/pull/66 for backend changes
##### Demo
<img width="847" alt="Screen Shot 2022-04-13 at 10 54 49 PM" src="https://user-images.githubusercontent.com/18358581/163322883-f6b8ced4-be45-4589-8e34-d01f24cf6fef.png">
<img width="830" alt="Screen Shot 2022-04-13 at 10 54 58 PM" src="https://user-images.githubusercontent.com/18358581/163322876-825b7284-63ef-4c59-9d88-828367b9e410.png">

