### PR TITLE
remove snackbar on task completion

### DIFF
--- a/modules/flok/src/store/actions/api.tsx
+++ b/modules/flok/src/store/actions/api.tsx
@@ -63,7 +63,6 @@ export function createApiAction(
     onSuccess?: (dispatch: ThunkDispatch<any, any, Action<any>>) => void
     errorMessage?: string
     onError?: (dispatch: ThunkDispatch<any, any, Action<any>>) => void
-    disableSnackbar?: boolean
   } = {}
 ) {
   return async (
@@ -77,7 +76,7 @@ export function createApiAction(
       if (apiOptions.onError) {
         apiOptions.onError(dispatch)
       }
-      if (apiOptions.errorMessage && !apiOptions.disableSnackbar) {
+      if (apiOptions.errorMessage) {
         dispatch(
           enqueueSnackbar({
             message: apiOptions.errorMessage,
@@ -99,7 +98,7 @@ export function createApiAction(
       if (apiOptions.onSuccess) {
         apiOptions.onSuccess(dispatch)
       }
-      if (apiOptions.successMessage && !apiOptions.disableSnackbar) {
+      if (apiOptions.successMessage) {
         dispatch(
           enqueueSnackbar({
             message: apiOptions.successMessage,

--- a/modules/flok/src/store/actions/api.tsx
+++ b/modules/flok/src/store/actions/api.tsx
@@ -63,6 +63,7 @@ export function createApiAction(
     onSuccess?: (dispatch: ThunkDispatch<any, any, Action<any>>) => void
     errorMessage?: string
     onError?: (dispatch: ThunkDispatch<any, any, Action<any>>) => void
+    disableSnackbar?: boolean
   } = {}
 ) {
   return async (
@@ -76,7 +77,7 @@ export function createApiAction(
       if (apiOptions.onError) {
         apiOptions.onError(dispatch)
       }
-      if (apiOptions.errorMessage) {
+      if (apiOptions.errorMessage && !apiOptions.disableSnackbar) {
         dispatch(
           enqueueSnackbar({
             message: apiOptions.errorMessage,
@@ -98,7 +99,7 @@ export function createApiAction(
       if (apiOptions.onSuccess) {
         apiOptions.onSuccess(dispatch)
       }
-      if (apiOptions.successMessage) {
+      if (apiOptions.successMessage && !apiOptions.disableSnackbar) {
         dispatch(
           enqueueSnackbar({
             message: apiOptions.successMessage,

--- a/modules/flok/src/store/actions/retreat.tsx
+++ b/modules/flok/src/store/actions/retreat.tsx
@@ -240,8 +240,7 @@ export function putRetreatTask(
     },
     {
       errorMessage: "Oops, something went wrong.",
-      successMessage: "Success!",
-      disableSnackbar: new_state === "COMPLETED",
+      successMessage: new_state !== "COMPLETED" ? "Success!" : undefined,
     }
   )
 }

--- a/modules/flok/src/store/actions/retreat.tsx
+++ b/modules/flok/src/store/actions/retreat.tsx
@@ -238,6 +238,10 @@ export function putRetreatTask(
         },
       ],
     },
-    {errorMessage: "Oops, something went wrong.", successMessage: "Success!"}
+    {
+      errorMessage: "Oops, something went wrong.",
+      successMessage: "Success!",
+      disableSnackbar: new_state === "COMPLETED",
+    }
   )
 }

--- a/modules/flok/src/store/actions/retreat.tsx
+++ b/modules/flok/src/store/actions/retreat.tsx
@@ -240,7 +240,6 @@ export function putRetreatTask(
     },
     {
       errorMessage: "Oops, something went wrong.",
-      successMessage: new_state !== "COMPLETED" ? "Success!" : undefined,
     }
   )
 }


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-300

##### Description
Removes snackbar notification when new_state is completed for a task.
##### Demo
