### PR TITLE
change from faq to budget link

### DIFF
--- a/modules/flok/src/components/page/PageSidenav.tsx
+++ b/modules/flok/src/components/page/PageSidenav.tsx
@@ -138,7 +138,6 @@ export default function PageSidenav(props: PageSidenavProps) {
         button: true,
         href: link,
         component: "a",
-        target: "_blank",
       }
     } else {
       return {
@@ -206,7 +205,7 @@ export default function PageSidenav(props: PageSidenavProps) {
           </ListItemIcon>
           <ListItemText>Itinerary</ListItemText>
         </ListItem>
-        <ListItem {...getLinkSidenavProps(retreatModel.faq_link)}>
+        <ListItem {...getLinkSidenavProps(retreatModel.budget_link)}>
           <ListItemIcon>
             <LocalAtm fontSize="large" />
           </ListItemIcon>


### PR DESCRIPTION
#### Linear 🎫 
N/A
##### Description
Makes page sidebar point to retreat.budget_link. uses that name instead of budget_link_url bc it already existed in the models.

##### Demo
