### PR TITLE
add retreat state updates to task form

### DIFF
--- a/modules/flok-admin/src/components/tasks/TaskForm.tsx
+++ b/modules/flok-admin/src/components/tasks/TaskForm.tsx
@@ -10,6 +10,13 @@ import _ from "lodash"
 import {useEffect} from "react"
 import {useDispatch, useSelector} from "react-redux"
 import * as yup from "yup"
+import {
+  OrderedRetreatAttendeesState,
+  OrderedRetreatFlightsState,
+  OrderedRetreatIntakeState,
+  OrderedRetreatItineraryState,
+  OrderedRetreatLodgingState,
+} from "../../models"
 import {RootState} from "../../store"
 import {getTask, patchTask} from "../../store/actions/admin"
 import {getTextFieldErrorProps} from "../../utils"
@@ -55,6 +62,11 @@ let useStyles = makeStyles((theme) => ({
   dropDown: {
     minWidth: "140px",
     marginBottom: theme.spacing(1.25),
+    marginRight: theme.spacing(1.25),
+  },
+  stateFields: {
+    display: "flex",
+    width: "100%",
   },
 }))
 
@@ -78,6 +90,13 @@ function TaskForm(props: TaskTableProps) {
       description: task?.description ?? "",
       link: task?.link ?? "",
       is_flok_task: task?.is_flok_task ?? false,
+      state_updates: {
+        intake_state: task?.state_updates?.intake_state,
+        lodging_state: task?.state_updates?.lodging_state,
+        attendees_state: task?.state_updates?.attendees_state,
+        flights_state: task?.state_updates?.flights_state,
+        itinerary_state: task?.state_updates?.itinerary_state,
+      },
     },
     validationSchema: yup.object({
       title: yup.string(),
@@ -139,7 +158,101 @@ function TaskForm(props: TaskTableProps) {
           value={formik.values.description}
           label="Description"
         />
-
+        <Typography className={classes.header} variant="h4">
+          Retreat Updates upon Completion
+        </Typography>
+        <div className={classes.stateFields}>
+          <TextField
+            className={classes.dropDown}
+            id="state_updates.intake_state"
+            label="Intake State"
+            select
+            SelectProps={{native: true}}
+            onChange={(e) =>
+              formik.setFieldValue(
+                "state_updates.intake_state",
+                e.target.value === "NO_UPDATE" ? undefined : e.target.value
+              )
+            }
+            value={formik.values.state_updates.intake_state ?? "NO_UPDATE"}>
+            <option value={"NO_UPDATE"}>NO_UPDATE</option>
+            {OrderedRetreatIntakeState.map((v) => (
+              <option value={v}>{v}</option>
+            ))}
+          </TextField>
+          <TextField
+            className={classes.dropDown}
+            id="state_updates.lodging_state"
+            label="Lodging State"
+            select
+            SelectProps={{native: true}}
+            onChange={(e) =>
+              formik.setFieldValue(
+                "state_updates.lodging_state",
+                e.target.value === "NO_UPDATE" ? undefined : e.target.value
+              )
+            }
+            value={formik.values.state_updates.lodging_state ?? "NO_UPDATE"}>
+            <option value={"NO_UPDATE"}>NO_UPDATE</option>
+            {OrderedRetreatLodgingState.map((v) => (
+              <option value={v}>{v}</option>
+            ))}
+          </TextField>
+          <TextField
+            className={classes.dropDown}
+            id="state_updates.attendees_state"
+            label="Attendees State"
+            select
+            SelectProps={{native: true}}
+            onChange={(e) =>
+              formik.setFieldValue(
+                "state_updates.attendees_state",
+                e.target.value === "NO_UPDATE" ? undefined : e.target.value
+              )
+            }
+            value={formik.values.state_updates.attendees_state ?? "NO_UPDATE"}>
+            <option value={"NO_UPDATE"}>NO_UPDATE</option>
+            {OrderedRetreatAttendeesState.map((v) => (
+              <option value={v}>{v}</option>
+            ))}
+          </TextField>
+          <TextField
+            className={classes.dropDown}
+            id="state_updates.flights_state"
+            label="Flights State"
+            select
+            SelectProps={{native: true}}
+            onChange={(e) =>
+              formik.setFieldValue(
+                "state_updates.flights_state",
+                e.target.value === "NO_UPDATE" ? undefined : e.target.value
+              )
+            }
+            value={formik.values.state_updates.flights_state ?? "NO_UPDATE"}>
+            <option value={"NO_UPDATE"}>NO_UPDATE</option>
+            {OrderedRetreatFlightsState.map((v) => (
+              <option value={v}>{v}</option>
+            ))}
+          </TextField>
+          <TextField
+            className={classes.dropDown}
+            id="state_updates.itinerary_state"
+            label="Itinerary State"
+            select
+            SelectProps={{native: true}}
+            onChange={(e) =>
+              formik.setFieldValue(
+                "state_updates.itinerary_state",
+                e.target.value === "NO_UPDATE" ? undefined : e.target.value
+              )
+            }
+            value={formik.values.state_updates.itinerary_state ?? "NO_UPDATE"}>
+            <option value={"NO_UPDATE"}>NO_UPDATE</option>
+            {OrderedRetreatItineraryState.map((v) => (
+              <option value={v}>{v}</option>
+            ))}
+          </TextField>
+        </div>
         <div className={classes.footer}>
           <Button
             variant="contained"

--- a/modules/flok-admin/src/models/index.tsx
+++ b/modules/flok-admin/src/models/index.tsx
@@ -267,6 +267,13 @@ export type RetreatTask = {
   description?: string
   link?: string
   is_flok_task: Boolean
+  state_updates?: {
+    intake_state?: RetreatIntakeState
+    lodging_state?: RetreatLodgingState
+    attendees_state?: RetreatAttendeesState
+    flights_state?: RetreatFlightsState
+    itinerary_state?: RetreatItineraryState
+  }
 }
 
 export type RetreatToTask = {

--- a/modules/flok-admin/src/store/actions/admin.tsx
+++ b/modules/flok-admin/src/store/actions/admin.tsx
@@ -675,7 +675,7 @@ export function patchTask(task_id: string, taskDetails: Partial<RetreatTask>) {
     endpoint,
     method: "PATCH",
     body: JSON.stringify(taskDetails, (key, value) =>
-      typeof value === "undefined" ? null : value
+      typeof value === "undefined" && !key.endsWith("_state") ? null : value
     ),
     types: [
       {type: PATCH_TASK_REQUEST, meta: {task_id}},

--- a/modules/flok-admin/src/store/actions/admin.tsx
+++ b/modules/flok-admin/src/store/actions/admin.tsx
@@ -675,7 +675,7 @@ export function patchTask(task_id: string, taskDetails: Partial<RetreatTask>) {
     endpoint,
     method: "PATCH",
     body: JSON.stringify(taskDetails, (key, value) =>
-      typeof value === "undefined" && !key.endsWith("_state") ? null : value
+      typeof value === "undefined" ? null : value
     ),
     types: [
       {type: PATCH_TASK_REQUEST, meta: {task_id}},


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-285

##### Description
Adds more fields to task form to allow users to select what retreat states are updated when a task is completed.
backend changes: https://github.com/Summ-Technologies/flok-backend/pull/70

###
<img width="1149" alt="Screen Shot 2022-04-25 at 1 16 34 PM" src="https://user-images.githubusercontent.com/18358581/165168428-94cc523d-6ded-438c-ae19-b017fd818ae2.png">
## Demo
