### PR TITLE
fix extra tasks completion bug

### DIFF
--- a/modules/flok/src/components/overview/AppTaskList.tsx
+++ b/modules/flok/src/components/overview/AppTaskList.tsx
@@ -178,6 +178,7 @@ export default function AppTodoList(props: {
   handleCheckboxClick: (task: RetreatToTask) => void
   orderBadge: boolean
   collapsed?: boolean
+  noComplete?: boolean
 }) {
   let classes = useListStyles(props)
   return (
@@ -194,7 +195,7 @@ export default function AppTodoList(props: {
             color="primary">
             <TodoListItem
               task={task}
-              disabled={i !== 0}
+              disabled={i !== 0 || !!props.noComplete}
               handleCheckboxClick={props.handleCheckboxClick}
             />
           </Badge>

--- a/modules/flok/src/pages/RetreatOverviewPage.tsx
+++ b/modules/flok/src/pages/RetreatOverviewPage.tsx
@@ -18,6 +18,7 @@ import AppTodoList from "../components/overview/AppTaskList"
 import PageBody from "../components/page/PageBody"
 import PageContainer from "../components/page/PageContainer"
 import PageSidenav from "../components/page/PageSidenav"
+import config, {MAX_TASKS} from "../config"
 import {
   OrderedRetreatAttendeesState,
   OrderedRetreatFlightsState,
@@ -191,10 +192,10 @@ function RetreatOverviewPage(props: RetreatOverviewProps) {
 
   let [todoTasksCollapsed, setTodoTasksCollapsed] = useState(true)
   let [completedTasksCollapsed, setCompletedTasksCollapsed] = useState(true)
-  const MAX_TASKS_SHOWN = 0
-  // parseInt(config.get(MAX_TASKS)) > 0
-  //   ? parseInt(config.get(MAX_TASKS))
-  //   : undefined
+  const MAX_TASKS_SHOWN =
+    parseInt(config.get(MAX_TASKS)) > 0
+      ? parseInt(config.get(MAX_TASKS))
+      : undefined
   let [todoTasks, setTodoTasks] = useState<RetreatToTask[]>([])
   let [todoTasksExtra, setTodoTasksExtra] = useState<RetreatToTask[]>([])
 

--- a/modules/flok/src/pages/RetreatOverviewPage.tsx
+++ b/modules/flok/src/pages/RetreatOverviewPage.tsx
@@ -18,7 +18,6 @@ import AppTodoList from "../components/overview/AppTaskList"
 import PageBody from "../components/page/PageBody"
 import PageContainer from "../components/page/PageContainer"
 import PageSidenav from "../components/page/PageSidenav"
-import config, {MAX_TASKS} from "../config"
 import {
   OrderedRetreatAttendeesState,
   OrderedRetreatFlightsState,
@@ -192,10 +191,10 @@ function RetreatOverviewPage(props: RetreatOverviewProps) {
 
   let [todoTasksCollapsed, setTodoTasksCollapsed] = useState(true)
   let [completedTasksCollapsed, setCompletedTasksCollapsed] = useState(true)
-  const MAX_TASKS_SHOWN =
-    parseInt(config.get(MAX_TASKS)) > 0
-      ? parseInt(config.get(MAX_TASKS))
-      : undefined
+  const MAX_TASKS_SHOWN = 0
+  // parseInt(config.get(MAX_TASKS)) > 0
+  //   ? parseInt(config.get(MAX_TASKS))
+  //   : undefined
   let [todoTasks, setTodoTasks] = useState<RetreatToTask[]>([])
   let [todoTasksExtra, setTodoTasksExtra] = useState<RetreatToTask[]>([])
 
@@ -281,6 +280,7 @@ function RetreatOverviewPage(props: RetreatOverviewProps) {
                 handleCheckboxClick={handleTaskClick}
                 orderBadge={true}
                 collapsed={todoTasksCollapsed}
+                noComplete
               />
               <Box marginTop={2}>
                 <Typography


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-310

##### Description
Fixes bug that allowed the first item in extra todo tasks to be clicked by adding a new optional "noComplete" prop to AppTaskList which when set to true does not allow any tasks to be clicked.
##### Demo
