### PR TITLE
Fix Proposal List Padding Issue

### DIFF
--- a/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
+++ b/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
@@ -183,13 +183,13 @@ export default function ProposalsListPageBody(
           }
         })}
         {/* Unavailable hotels render */}
-        {unavailableSelectedHotels.length ? (
-          <AppTypography variant="h2">
-            Unavailable Hotels{" "}
-            <AppMoreInfoIcon tooltipText="We reached out to the following hotels but they cannot support your group during the requested dates." />
-          </AppTypography>
-        ) : undefined}
         <div className={classes.proposalsList}>
+          {unavailableSelectedHotels.length ? (
+            <AppTypography variant="h2">
+              Unavailable Hotels{" "}
+              <AppMoreInfoIcon tooltipText="We reached out to the following hotels but they cannot support your group during the requested dates." />
+            </AppTypography>
+          ) : undefined}
           {unavailableSelectedHotels.map((selectedHotel) => {
             let hotel = hotelsById[selectedHotel.hotel_id]
             let destination = destinations[hotel.destination_id]


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-309

##### Description
Moves "Unavailable Hotels" title into the proposalsList div so the margin goes above it rather than below.

##### Demo
<img width="1059" alt="Screen Shot 2022-05-03 at 1 14 17 AM" src="https://user-images.githubusercontent.com/18358581/166422565-215267d9-5902-4674-860e-4a9ab5febda6.png">

