### PR TITLE
Center Page Locked Modal

### DIFF
--- a/modules/flok/src/components/page/PageBody.tsx
+++ b/modules/flok/src/components/page/PageBody.tsx
@@ -1,6 +1,7 @@
 import {makeStyles} from "@material-ui/core"
-import React, {PropsWithChildren} from "react"
+import React, {PropsWithChildren, useRef} from "react"
 import PageAppBar from "./PageAppBar"
+import PageLockedModal from "./PageLockedModal"
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -14,15 +15,27 @@ const useStyles = makeStyles((theme) => ({
     overflow: "auto",
     display: "flex",
     flexDirection: "column",
+    position: "relative",
   },
 }))
 
-type PageBodyProps = PropsWithChildren<{appBar?: boolean}>
+type PageBodyProps = PropsWithChildren<{
+  appBar?: boolean
+  locked?: boolean
+  lockedText?: string
+}>
 export default function PageBody(props: PageBodyProps) {
   const classes = useStyles(props)
+  const bodyRef = useRef<HTMLDivElement>(null)
   return (
     <div className={classes.root}>
-      <div className={classes.body}>
+      <div className={classes.body} ref={bodyRef}>
+        {props.locked && (
+          <PageLockedModal
+            pageDesc={props.lockedText}
+            container={bodyRef.current ?? undefined}
+          />
+        )}
         {props.appBar && <PageAppBar />}
         {props.children}
       </div>

--- a/modules/flok/src/components/page/PageLockedModal.tsx
+++ b/modules/flok/src/components/page/PageLockedModal.tsx
@@ -2,10 +2,11 @@ import {Dialog, makeStyles} from "@material-ui/core"
 import {FlokTheme} from "../../theme"
 import UnderConstructionView from "./UnderConstructionView"
 
-function PageLockedModal(props: {pageDesc?: string}) {
+function PageLockedModal(props: {pageDesc?: string; container?: HTMLElement}) {
   let useStyles = makeStyles((theme: FlokTheme) => ({
     MuiBackdrop: {
       backdropFilter: "blur(2px)",
+      position: "absolute",
     },
   }))
   let classes = useStyles()
@@ -15,7 +16,10 @@ function PageLockedModal(props: {pageDesc?: string}) {
       aria-labelledby="simple-dialog-title"
       open={true}
       disableBackdropClick={false}
-      style={{zIndex: 1000}}
+      style={{zIndex: 1000, position: "absolute"}}
+      container={props.container ?? document.body}
+      BackdropProps={{style: {position: "absolute"}}}
+      disablePortal
       classes={{
         root: classes.MuiBackdrop,
       }}>

--- a/modules/flok/src/pages/RetreatAttendeesPage.tsx
+++ b/modules/flok/src/pages/RetreatAttendeesPage.tsx
@@ -32,7 +32,6 @@ import AppExpandableTable from "../components/base/AppExpandableTable"
 import AppTypography from "../components/base/AppTypography"
 import PageBody from "../components/page/PageBody"
 import PageContainer from "../components/page/PageContainer"
-import PageLockedModal from "../components/page/PageLockedModal"
 import PageSidenav from "../components/page/PageSidenav"
 import {RetreatAttendeeModel, SampleLockedAttendees} from "../models/retreat"
 import {AppRoutes} from "../Stack"
@@ -209,12 +208,11 @@ function RetreatAttendeesPage(props: RetreatAttendeesProps) {
   return (
     <PageContainer>
       <PageSidenav activeItem="attendees" retreatIdx={retreatIdx} />
-      <PageBody appBar>
+      <PageBody
+        appBar
+        locked={retreat.attendees_state !== "REGISTRATION_OPEN"}
+        lockedText="This page will be unlocked when attendee registration opens">
         <div className={classes.section}>
-          {retreat.attendees_state !== "REGISTRATION_OPEN" && (
-            <PageLockedModal pageDesc="This page will be unlocked when attendee registration opens" />
-          )}
-
           <Box
             display="flex"
             justifyContent="space-between"

--- a/modules/flok/src/pages/RetreatFlightsPage.tsx
+++ b/modules/flok/src/pages/RetreatFlightsPage.tsx
@@ -21,7 +21,6 @@ import AppMoreInfoIcon from "../components/base/AppMoreInfoIcon"
 import AppTypography from "../components/base/AppTypography"
 import PageBody from "../components/page/PageBody"
 import PageContainer from "../components/page/PageContainer"
-import PageLockedModal from "../components/page/PageLockedModal"
 import PageSidenav from "../components/page/PageSidenav"
 import {SampleLockedAttendees} from "../models/retreat"
 import {AppRoutes} from "../Stack"
@@ -119,16 +118,16 @@ function RetreatFlightsPage(props: RetreatFlightsProps) {
   return (
     <PageContainer>
       <PageSidenav activeItem="flights" retreatIdx={retreatIdx} />
-      <PageBody appBar>
+      <PageBody
+        appBar
+        locked={retreat.flights_state !== "BOOKING"}
+        lockedText="This page will be unlocked when flight booking begins">
         <div className={classes.section}>
           <Box
             display="flex"
             justifyContent="space-between"
             alignItems="flex-end">
             <Typography variant="h1">Flights</Typography>
-            {retreat.flights_state !== "BOOKING" && (
-              <PageLockedModal pageDesc="This page will be unlocked when flight booking begins" />
-            )}
             <Link
               variant="body1"
               underline="always"

--- a/modules/flok/src/pages/RetreatItineraryPage.tsx
+++ b/modules/flok/src/pages/RetreatItineraryPage.tsx
@@ -3,7 +3,6 @@ import {useEffect} from "react"
 import {RouteComponentProps, withRouter} from "react-router-dom"
 import PageBody from "../components/page/PageBody"
 import PageContainer from "../components/page/PageContainer"
-import PageLockedModal from "../components/page/PageLockedModal"
 import PageSidenav from "../components/page/PageSidenav"
 import {useRetreat} from "./misc/RetreatProvider"
 
@@ -76,13 +75,15 @@ function RetreatItineraryPage(props: RetreatItineraryPageProps) {
     <PageContainer>
       {/* <PageSidenav activeItem="itinerary" retreatIdx={retreatIdx} /> */}
       <PageSidenav retreatIdx={retreatIdx} />
-      <PageBody appBar>
+      <PageBody
+        appBar
+        locked={
+          retreat.itinerary_state !== "IN_PROGRESS" ||
+          !retreat.itinerary_final_draft_link
+        }
+        lockedText="This page will be unlocked when we begin booking your itinerary">
         <div className={classes.root}>
           <Typography variant="h1">Itinerary</Typography>
-          {(retreat.itinerary_state !== "IN_PROGRESS" ||
-            !retreat.itinerary_final_draft_link) && (
-            <PageLockedModal pageDesc="This page will be unlocked when we begin booking your itinerary" />
-          )}
           {/* Commenting out itinerary page body because now will be using link directly to itinerary document */}
           {/* <div className={classes.linksDiv}>
             <Box className={classes.draftBox}>


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-314

##### Description
Centers PageLockedModal within the pagebody rather than the entire document. To do this, the component had to be created within the PageBody component so its references have been removed and instead the logic for rendering it is now handled by PageBody.

##### Demo
<img width="1014" alt="Screen Shot 2022-05-03 at 2 10 12 AM" src="https://user-images.githubusercontent.com/18358581/166429392-2f885868-b7fe-47f8-b02f-14de368a826b.png">

