### PR TITLE
Prettify No Proposals Message

### DIFF
--- a/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
+++ b/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
@@ -1,5 +1,6 @@
-import {Box, makeStyles, Typography} from "@material-ui/core"
-import React, {useEffect, useState} from "react"
+import {Box, Dialog, makeStyles, Typography} from "@material-ui/core"
+import {KingBedOutlined} from "@material-ui/icons"
+import React, {useEffect, useRef, useState} from "react"
 import {useDispatch, useSelector} from "react-redux"
 import {HotelModel} from "../../models/lodging"
 import {RetreatModel, RetreatSelectedHotelProposal} from "../../models/retreat"
@@ -20,6 +21,7 @@ let useStyles = makeStyles((theme) => ({
     width: "100%",
     flex: 1,
     height: "100%",
+    position: "relative",
   },
   header: {},
   proposalsList: {
@@ -31,6 +33,24 @@ let useStyles = makeStyles((theme) => ({
     "& > *:not(:first-child)": {
       marginTop: theme.spacing(1),
     },
+  },
+  noHotelsModalBody: {
+    maxWidth: "40vw",
+    maxHeight: "40vh",
+    minWidth: 300,
+    minHeight: 300,
+    height: "100%",
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    alignContent: "baseline",
+    justifyContent: "center",
+    padding: 24,
+    textAlign: "center",
+  },
+  modalHeader: {
+    marginBottom: theme.spacing(1),
   },
 }))
 
@@ -126,8 +146,10 @@ export default function ProposalsListPageBody(
     )
     newTab?.focus()
   }
+
+  let dialogContainerRef = useRef<HTMLDivElement>(null)
   return (
-    <div className={classes.root}>
+    <div className={classes.root} ref={dialogContainerRef}>
       <div className={classes.header}>
         <Typography variant="h1">
           Lodging
@@ -147,12 +169,34 @@ export default function ProposalsListPageBody(
         {groupedSelectedHotels.length + unavailableSelectedHotels.length ===
         0 ? (
           loadingHotels ? (
-            <AppTypography variant="body1">Loading...</AppTypography>
-          ) : (
-            <AppTypography variant="body1">
-              Check back soon. We're currently working on collecting hotel
-              proposals on your behalf!
+            <AppTypography variant="body1" fontWeight="bold">
+              Loading...
             </AppTypography>
+          ) : (
+            <Dialog
+              open={true}
+              maxWidth="sm"
+              hideBackdrop
+              style={{position: "absolute"}}
+              container={dialogContainerRef.current ?? document.body}>
+              <div className={classes.noHotelsModalBody}>
+                <AppTypography
+                  variant="h1"
+                  fontWeight="bold"
+                  uppercase
+                  className={classes.modalHeader}>
+                  <KingBedOutlined fontSize="large" /> Check Back Soon{" "}
+                  <KingBedOutlined fontSize="large" />
+                </AppTypography>
+                <AppTypography variant="body1">
+                  We're currently working on collecting hotel proposals on your
+                  behalf! We'll let you know when we've added proposals to the
+                  database.
+                </AppTypography>
+              </div>
+            </Dialog>
+            // <Paper elevation={0} className={classes.noHotelsMsg}>
+            // </Paper>
           )
         ) : undefined}
         {/* Available hotels render */}

--- a/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
+++ b/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
@@ -1,4 +1,4 @@
-import {Box, Dialog, makeStyles, Typography} from "@material-ui/core"
+import {Box, makeStyles, Typography} from "@material-ui/core"
 import {KingBedOutlined} from "@material-ui/icons"
 import React, {useEffect, useRef, useState} from "react"
 import {useDispatch, useSelector} from "react-redux"
@@ -11,6 +11,7 @@ import {theme} from "../../theme"
 import {DestinationUtils, useDestinations} from "../../utils/lodgingUtils"
 import AppMoreInfoIcon from "../base/AppMoreInfoIcon"
 import AppTypography from "../base/AppTypography"
+import PageLockedModal from "../page/PageLockedModal"
 import ProposalListRow from "./ProposalListRow"
 
 let useStyles = makeStyles((theme) => ({
@@ -173,30 +174,12 @@ export default function ProposalsListPageBody(
               Loading...
             </AppTypography>
           ) : (
-            <Dialog
-              open={true}
-              maxWidth="sm"
-              hideBackdrop
-              style={{position: "absolute"}}
-              container={dialogContainerRef.current ?? document.body}>
-              <div className={classes.noHotelsModalBody}>
-                <AppTypography
-                  variant="h1"
-                  fontWeight="bold"
-                  uppercase
-                  className={classes.modalHeader}>
-                  <KingBedOutlined fontSize="large" /> Check Back Soon{" "}
-                  <KingBedOutlined fontSize="large" />
-                </AppTypography>
-                <AppTypography variant="body1">
-                  We're currently working on collecting hotel proposals on your
-                  behalf! We'll let you know when we've added proposals to the
-                  database.
-                </AppTypography>
-              </div>
-            </Dialog>
-            // <Paper elevation={0} className={classes.noHotelsMsg}>
-            // </Paper>
+            <PageLockedModal
+              header="Check Back Soon"
+              pageDesc="We're currently working on collecting hotel proposals on your behalf! We'll let you know when we've added proposals to the database."
+              headerIcon={KingBedOutlined}
+              noBackdrop
+            />
           )
         ) : undefined}
         {/* Available hotels render */}

--- a/modules/flok/src/components/page/PageLockedModal.tsx
+++ b/modules/flok/src/components/page/PageLockedModal.tsx
@@ -1,8 +1,14 @@
-import {Dialog, makeStyles} from "@material-ui/core"
+import {Dialog, makeStyles, SvgIconTypeMap} from "@material-ui/core"
+import {OverridableComponent} from "@material-ui/core/OverridableComponent"
 import {FlokTheme} from "../../theme"
 import UnderConstructionView from "./UnderConstructionView"
 
-function PageLockedModal(props: {pageDesc?: string}) {
+function PageLockedModal(props: {
+  pageDesc?: string
+  header?: string
+  headerIcon?: OverridableComponent<SvgIconTypeMap<{}, "svg">>
+  noBackdrop?: boolean
+}) {
   let useStyles = makeStyles((theme: FlokTheme) => ({
     MuiBackdrop: {
       backdropFilter: "blur(2px)",
@@ -16,10 +22,15 @@ function PageLockedModal(props: {pageDesc?: string}) {
       open={true}
       disableBackdropClick={false}
       style={{zIndex: 1000}}
-      classes={{
-        root: classes.MuiBackdrop,
-      }}>
-      <UnderConstructionView pageDesc={props.pageDesc} />
+      hideBackdrop={props.noBackdrop}
+      classes={
+        !props.noBackdrop
+          ? {
+              root: classes.MuiBackdrop,
+            }
+          : {}
+      }>
+      <UnderConstructionView {...props} />
     </Dialog>
   )
 }

--- a/modules/flok/src/components/page/UnderConstructionView.tsx
+++ b/modules/flok/src/components/page/UnderConstructionView.tsx
@@ -1,9 +1,12 @@
-import {Icon, makeStyles} from "@material-ui/core"
+import {Icon, makeStyles, SvgIconTypeMap} from "@material-ui/core"
+import {OverridableComponent} from "@material-ui/core/OverridableComponent"
 import {LockRounded} from "@material-ui/icons"
 import AppTypography from "../base/AppTypography"
 
 type UnderConstructionViewProps = {
   pageDesc?: string
+  header?: string
+  headerIcon?: OverridableComponent<SvgIconTypeMap<{}, "svg">>
 }
 
 let useStyles = makeStyles((theme) => ({
@@ -62,18 +65,19 @@ export default function UnderConstructionView(
   props: UnderConstructionViewProps
 ) {
   let classes = useStyles(props)
+  const HeaderIcon = props.headerIcon ?? LockRounded
   return (
     <div className={classes.body}>
       <div className={classes.modal}>
         <div className={classes.header}>
           <Icon fontSize="large">
-            <LockRounded fontSize="large" style={{verticalAlign: "top"}} />
+            <HeaderIcon fontSize="large" style={{verticalAlign: "top"}} />
           </Icon>
           <AppTypography variant="h1" uppercase>
-            &nbsp;Coming Soon&nbsp;
+            &nbsp;{props.header ?? "Coming Soon"}&nbsp;
           </AppTypography>
           <Icon fontSize="large">
-            <LockRounded fontSize="large" style={{verticalAlign: "top"}} />
+            <HeaderIcon fontSize="large" style={{verticalAlign: "top"}} />
           </Icon>
         </div>
         <div className={classes.modalBody}>


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-313

##### Description
Changes the lodging page to display a prettier modal when no lodging proposals are available to view.
Repurposes the PageLockedModal in order to reduce code redundancy.

**NOTE**: After merging this other PR (https://github.com/Summ-Technologies/flok/pull/149) this PR should be updated to add the `container={dialogContainerRef.current}` prop to PageLockedModal near line 177 of ProposalsListPageBody.tsx in order to center it within the page content.

##### Demo
<img width="1020" alt="Screen Shot 2022-05-03 at 1 11 36 PM" src="https://user-images.githubusercontent.com/18358581/166558096-302b7d26-9059-497c-b4cb-ad967339b12d.png">

