### PR TITLE
Always show itinerary link and fix budget link from faq

### DIFF
--- a/modules/flok/src/components/page/PageSidenav.tsx
+++ b/modules/flok/src/components/page/PageSidenav.tsx
@@ -198,15 +198,13 @@ export default function PageSidenav(props: PageSidenavProps) {
           )
         })}
         <ListItem
-          {...(retreatModel.itinerary_state === "IN_PROGRESS"
-            ? getLinkSidenavProps(retreatModel.itinerary_final_draft_link)
-            : getLinkSidenavProps())}>
+          {...getLinkSidenavProps(retreatModel.itinerary_final_draft_link)}>
           <ListItemIcon>
             <MapRounded fontSize="large" />
           </ListItemIcon>
           <ListItemText>Itinerary</ListItemText>
         </ListItem>
-        <ListItem {...getLinkSidenavProps(retreatModel.faq_link)}>
+        <ListItem {...getLinkSidenavProps(retreatModel.budget_link)}>
           <ListItemIcon>
             <LocalAtm fontSize="large" />
           </ListItemIcon>


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-318/clicking-on-budget-icon-is-taking-me-to-the-faqs-document
https://linear.app/flok/issue/FLO-317/make-itinerary-and-budget-tabs-immediately-clickable

##### Description

##### Demo
