### PR TITLE
replaced empty screens with locked page modals initial

### DIFF
--- a/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
+++ b/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
@@ -138,7 +138,7 @@ export default function ProposalsListPageBody(
           loadingHotels ? (
             <AppTypography variant="body1">Loading...</AppTypography>
           ) : (
-            <PageLockedModal pageDesc="We're currently working on collecting hotel proposals on your behalf!" />
+            <PageLockedModal pageDesc="We're currently working on collecting hotel proposals on your behalf and will let you know they are ready to view!" />
           )
         ) : undefined}
         {/* Available hotels render */}

--- a/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
+++ b/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
@@ -9,6 +9,7 @@ import {theme} from "../../theme"
 import {DestinationUtils, useDestinations} from "../../utils/lodgingUtils"
 import AppMoreInfoIcon from "../base/AppMoreInfoIcon"
 import AppTypography from "../base/AppTypography"
+import PageLockedModal from "../page/PageLockedModal"
 import ProposalListRow from "./ProposalListRow"
 
 let useStyles = makeStyles((theme) => ({
@@ -137,10 +138,7 @@ export default function ProposalsListPageBody(
           loadingHotels ? (
             <AppTypography variant="body1">Loading...</AppTypography>
           ) : (
-            <AppTypography variant="body1">
-              Check back soon. We're currently working on collecting hotel
-              proposals on your behalf!
-            </AppTypography>
+            <PageLockedModal pageDesc="We're currently working on collecting hotel proposals on your behalf!" />
           )
         ) : undefined}
         {/* Available hotels render */}

--- a/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
+++ b/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
@@ -138,7 +138,7 @@ export default function RetreatHotelPageBody(props: RetreatHotelPageBodyProps) {
       {loadingHotel ? (
         <AppLoadingScreen />
       ) : hotel === undefined ? (
-        <PageLockedModal pageDesc="This page will be unlocked when the contract phase begins" />
+        <PageLockedModal pageDesc="This page will unlock once your hotel contract is finalized and signed!" />
       ) : (
         <Grid container className={classes.hotelBody}>
           <Grid

--- a/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
+++ b/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
@@ -15,6 +15,7 @@ import {RootState} from "../../store"
 import {getHotels} from "../../store/actions/lodging"
 import AppImageGrid from "../base/AppImageGrid"
 import AppLoadingScreen from "../base/AppLoadingScreen"
+import PageLockedModal from "../page/PageLockedModal"
 
 let useStyles = makeStyles((theme) => ({
   root: {
@@ -137,7 +138,7 @@ export default function RetreatHotelPageBody(props: RetreatHotelPageBodyProps) {
       {loadingHotel ? (
         <AppLoadingScreen />
       ) : hotel === undefined ? (
-        "Oops, something went wrong."
+        <PageLockedModal pageDesc="This page will be unlocked when the contract phase begins" />
       ) : (
         <Grid container className={classes.hotelBody}>
           <Grid


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-

##### Description
Added page locked modals to lodging contract and proposals when not started
##### Demo
<img width="1512" alt="Screen Shot 2022-05-17 at 2 31 01 PM" src="https://user-images.githubusercontent.com/41205015/168886759-96c660de-744a-45c7-9259-97f051ac5517.png">
<img width="1512" alt="Screen Shot 2022-05-17 at 2 30 57 PM" src="https://user-images.githubusercontent.com/41205015/168886777-938fd287-33d2-47a2-acab-2ef5817bec1e.png">
