### PR TITLE
Andrew/landing pages fixes

### DIFF
--- a/modules/flok/public/index.html
+++ b/modules/flok/public/index.html
@@ -9,7 +9,12 @@
       href="https://flok-b32d43c.s3.us-east-1.amazonaws.com/branding/logos/icon-white_bg-rounded@.5x.png"
       sizes="16x16"
     />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.3.1/themes/reset-min.css" integrity="sha256-t2ATOGCtAIZNnzER679jwcFcKYfLlw01gli6F6oszk8=" crossorigin="anonymous">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.3.1/themes/reset-min.css"
+      integrity="sha256-t2ATOGCtAIZNnzER679jwcFcKYfLlw01gli6F6oszk8="
+      crossorigin="anonymous"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -31,7 +36,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Flok | End-to-end company retreat planning</title>
+    <title id="titleTag">Flok | End-to-end company retreat planning</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/modules/flok/src/components/retreat-website/RetreatWebsiteHeader.tsx
+++ b/modules/flok/src/components/retreat-website/RetreatWebsiteHeader.tsx
@@ -75,6 +75,7 @@ type RetreatWebsiteHeaderProps = {
   retreatName: string
   selectedPage: string
   homeRoute: string
+  registrationLink?: string
 }
 
 function RetreatWebsiteHeader(props: RetreatWebsiteHeaderProps) {
@@ -105,13 +106,15 @@ function RetreatWebsiteHeader(props: RetreatWebsiteHeaderProps) {
             })}
           </div>
           <div className={classes.registerWrapper}>
-            <Button
-              color="primary"
-              variant="contained"
-              size="small"
-              className={classes.registerButton}>
-              Register Now
-            </Button>
+            <Link
+              href={props.registrationLink}
+              target="__blank"
+              className={classes.registerButton}
+              underline="none">
+              <Button size="large" color="primary" variant="contained">
+                Register Now
+              </Button>
+            </Link>
           </div>
         </>
       ) : (
@@ -137,13 +140,15 @@ function RetreatWebsiteHeader(props: RetreatWebsiteHeaderProps) {
                 )
               })}
             </div>
-            <Button
-              size="large"
-              color="primary"
-              variant="contained"
+
+            <Link
+              href={props.registrationLink}
+              target="__blank"
               className={classes.registerButton}>
-              Register Now
-            </Button>
+              <Button size="large" color="primary" variant="contained">
+                Register Now
+              </Button>
+            </Link>
           </Drawer>
         </>
       )}

--- a/modules/flok/src/components/retreat-website/WYSIWYGBlockEditor.tsx
+++ b/modules/flok/src/components/retreat-website/WYSIWYGBlockEditor.tsx
@@ -82,6 +82,7 @@ function WYSIWYGBlockEditor(props: WYSIWYGBlockEditorProps) {
       type: "WYSIWYG",
     },
     onSubmit: (values) => {
+      console.log(convertToRaw(values.content.getCurrentContent()))
       dispatch(
         patchBlock(props.blockId, {
           content: convertToRaw(values.content.getCurrentContent()),

--- a/modules/flok/src/components/retreat-website/WYSIWYGBlockEditor.tsx
+++ b/modules/flok/src/components/retreat-website/WYSIWYGBlockEditor.tsx
@@ -82,7 +82,6 @@ function WYSIWYGBlockEditor(props: WYSIWYGBlockEditorProps) {
       type: "WYSIWYG",
     },
     onSubmit: (values) => {
-      console.log(convertToRaw(values.content.getCurrentContent()))
       dispatch(
         patchBlock(props.blockId, {
           content: convertToRaw(values.content.getCurrentContent()),

--- a/modules/flok/src/models/api.tsx
+++ b/modules/flok/src/models/api.tsx
@@ -38,3 +38,8 @@ export type AttendeeLandingWebsitePageApiResponse = {
 export type AttendeeLandingWebsitePageBlockApiResponse = {
   block: AttendeeLandingWebsiteBlockModel
 }
+export type AttendeeLandingWebsiteInitializeApiResponse = {
+  website: AttendeeLandingWebsiteModel
+  page: AttendeeLandingWebsitePageModel
+  block: AttendeeLandingWebsiteBlockModel
+}

--- a/modules/flok/src/models/retreat.tsx
+++ b/modules/flok/src/models/retreat.tsx
@@ -138,6 +138,7 @@ export type RetreatModel = {
   // Retreat data related to attendees
   attendees_state?: RetreatAttendeesState
   attendees_website_id?: number
+  attendees_registration_form_link?: string
 
   // Retreat data related to flights
   flights_state?: RetreatFlightsState

--- a/modules/flok/src/pages/CreateRetreatWebsite.tsx
+++ b/modules/flok/src/pages/CreateRetreatWebsite.tsx
@@ -66,7 +66,7 @@ function CreateRetreatWebsite(props: CreateRetreatWebsiteProps) {
         push(
           AppRoutes.getPath("LandingPageGeneratorPage", {
             retreatIdx: retreatIdx.toString(),
-            currentPageId: websiteResponse.payload.page.id,
+            currentPageId: websiteResponse.payload.website.page_ids[0],
           })
         )
       )

--- a/modules/flok/src/pages/CreateRetreatWebsite.tsx
+++ b/modules/flok/src/pages/CreateRetreatWebsite.tsx
@@ -9,7 +9,7 @@ import PageBody from "../components/page/PageBody"
 import {UploadImage} from "../components/retreat-website/EditWebsiteForm"
 import {AppRoutes} from "../Stack"
 import {ApiAction} from "../store/actions/api"
-import {postPage, postWebsite} from "../store/actions/retreat"
+import {postInitialWebsite, postPage} from "../store/actions/retreat"
 import {getTextFieldErrorProps} from "../utils"
 import {useAttendeeLandingWebsite} from "../utils/retreatUtils"
 import {useRetreat} from "./misc/RetreatProvider"
@@ -59,25 +59,17 @@ function CreateRetreatWebsite(props: CreateRetreatWebsiteProps) {
     retreat_id: number
   }) {
     let websiteResponse = (await dispatch(
-      postWebsite(values)
+      postInitialWebsite(values)
     )) as unknown as ApiAction
     if (!websiteResponse.error) {
-      let pageResponse = (await dispatch(
-        postPage({
-          title: "Home",
-          website_id: websiteResponse.payload.website.id,
-        })
-      )) as unknown as ApiAction
-      if (!pageResponse.error) {
-        dispatch(
-          push(
-            AppRoutes.getPath("LandingPageGeneratorPage", {
-              retreatIdx: retreatIdx.toString(),
-              currentPageId: pageResponse.payload.page.id,
-            })
-          )
+      dispatch(
+        push(
+          AppRoutes.getPath("LandingPageGeneratorPage", {
+            retreatIdx: retreatIdx.toString(),
+            currentPageId: websiteResponse.payload.page.id,
+          })
         )
-      }
+      )
     }
   }
 

--- a/modules/flok/src/pages/LandingPageGenerator.tsx
+++ b/modules/flok/src/pages/LandingPageGenerator.tsx
@@ -271,7 +271,7 @@ function LandingPageGenerator(props: LandingPageGeneratorProps) {
               <Link
                 className={classes.viewPageLink}
                 href={AppRoutes.getPath("RetreatWebsitePage", {
-                  retreatName: website.name,
+                  retreatName: titleToNavigation(website.name),
                   pageName: titleToNavigation(page?.title ?? "home"),
                 })}
                 target="_blank">

--- a/modules/flok/src/pages/RetreatWebsite.tsx
+++ b/modules/flok/src/pages/RetreatWebsite.tsx
@@ -15,6 +15,7 @@ import {
   useAttendeeLandingPageName,
   useAttendeeLandingWebsiteName,
 } from "../utils/retreatUtils"
+import LoadingPage from "./misc/LoadingPage"
 import NotFound404Page from "./misc/NotFound404Page"
 
 let useStyles = makeStyles((theme) => ({
@@ -60,12 +61,16 @@ function RetreatWebsite(props: RetreatWebsiteProps) {
     })
     return strArray.join("")
   }
-  let website = useAttendeeLandingWebsiteName(replaceDashes(retreatName))
-  let page = useAttendeeLandingPageName(
+  let [website, websiteLoading] = useAttendeeLandingWebsiteName(
+    replaceDashes(retreatName)
+  )
+  let [page, pageLoading] = useAttendeeLandingPageName(
     website?.id ?? 0,
     replaceDashes(pageName ?? "home")
   )
   let [registrationLink, setRegistrationLink] = useState("")
+  const titleTag = document.getElementById("titleTag")
+  titleTag!.innerHTML = `${website?.name} | ${page?.title}`
   useEffect(() => {
     async function handleGetRetreat(retreatId: number) {
       let result = (await dispatch(
@@ -79,7 +84,9 @@ function RetreatWebsite(props: RetreatWebsiteProps) {
     }
     handleGetRetreat(website?.retreat_id ?? -1)
   }, [website?.retreat_id, dispatch])
-  return !page || !website ? (
+  return websiteLoading || pageLoading ? (
+    <LoadingPage />
+  ) : !page || !website ? (
     <NotFound404Page />
   ) : (
     <PageContainer>
@@ -88,7 +95,7 @@ function RetreatWebsite(props: RetreatWebsiteProps) {
           <RetreatWebsiteHeader
             logo={
               website.company_logo_img ??
-              "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Brex_logo_black.svg/1200px-Brex_logo_black.svg.png"
+              "https://goflok.com/_next/image?url=https%3A%2F%2Fflok-b32d43c.s3.amazonaws.com%2Flanding-page%2Flogo.png&w=256&q=75"
             }
             pageIds={website.page_ids}
             retreatName={retreatName}

--- a/modules/flok/src/pages/RetreatWebsite.tsx
+++ b/modules/flok/src/pages/RetreatWebsite.tsx
@@ -50,7 +50,6 @@ type RetreatWebsiteProps = RouteComponentProps<{
 function RetreatWebsite(props: RetreatWebsiteProps) {
   let {retreatName, pageName} = props.match.params
   let dispatch = useDispatch()
-
   let classes = useStyles()
   function replaceDashes(str: string) {
     let strArray = str.split("")

--- a/modules/flok/src/store/actions/retreat.tsx
+++ b/modules/flok/src/store/actions/retreat.tsx
@@ -546,27 +546,7 @@ export function deletePage(pageId: number) {
     {errorMessage: "Something went wrong"}
   )
 }
-export const POST_WEBSITE_REQUEST = "POST_WEBSITE_REQUEST"
-export const POST_WEBSITE_SUCCESS = "POST_WEBSITE_SUCCESS"
-export const POST_WEBSITE_FAILURE = "POST_WEBSITE_FAILURE"
-export function postWebsite(values: Partial<AttendeeLandingWebsiteModel>) {
-  let endpoint = `/v1.0/websites`
-  return createApiAction(
-    {
-      method: "POST",
-      endpoint,
-      body: JSON.stringify(values),
-      types: [
-        {type: POST_WEBSITE_REQUEST},
-        {type: POST_WEBSITE_SUCCESS},
-        {type: POST_WEBSITE_FAILURE},
-      ],
-    },
-    {
-      errorMessage: "Something went wrong.",
-    }
-  )
-}
+
 export const PATCH_WEBSITE_REQUEST = "PATCH_WEBSITE_REQUEST"
 export const PATCH_WEBSITE_SUCCESS = "PATCH_WEBSITE_SUCCESS"
 export const PATCH_WEBSITE_FAILURE = "PATCH_WEBSITE_FAILURE"
@@ -589,6 +569,30 @@ export function patchWebsite(
     {
       successMessage: "Succesfully updated website",
       errorMessage: "Something went wrong",
+    }
+  )
+}
+
+export const POST_INITIAL_WEBSITE_REQUEST = "POST_INITIAL_WEBSITE_REQUEST"
+export const POST_INITIAL_WEBSITE_SUCCESS = "POST_INITIAL_WEBSITE_SUCCESS"
+export const POST_INITIAL_WEBSITE_FAILURE = "POST_INITIAL_WEBSITE_FAILURE"
+export function postInitialWebsite(
+  values: Partial<AttendeeLandingWebsiteModel>
+) {
+  let endpoint = `/v1.0/websites/initialize`
+  return createApiAction(
+    {
+      method: "POST",
+      endpoint,
+      body: JSON.stringify(values),
+      types: [
+        {type: POST_INITIAL_WEBSITE_REQUEST},
+        {type: POST_INITIAL_WEBSITE_SUCCESS},
+        {type: POST_INITIAL_WEBSITE_FAILURE},
+      ],
+    },
+    {
+      errorMessage: "Something went wrong.",
     }
   )
 }

--- a/modules/flok/src/store/reducers/retreat.tsx
+++ b/modules/flok/src/store/reducers/retreat.tsx
@@ -16,6 +16,11 @@ import {
   RetreatModel,
   RetreatTripModel,
 } from "../../models/retreat"
+import {
+  reduceBlockPost,
+  reducePagePost,
+  reduceWebsitePost,
+} from "../../utils/retreatUtils"
 import {ApiAction} from "../actions/api"
 import {
   DELETE_PAGE_SUCCESS,
@@ -38,9 +43,9 @@ import {
   PATCH_TRIP_SUCCESS,
   PATCH_WEBSITE_SUCCESS,
   POST_BLOCK_SUCCESS,
+  POST_INITIAL_WEBSITE_SUCCESS,
   POST_PAGE_SUCCESS,
   POST_RETREAT_ATTENDEES_SUCCESS,
-  POST_WEBSITE_SUCCESS,
   PUT_RETREAT_PREFERENCES_SUCCESS,
   PUT_RETREAT_TASK_SUCCESS,
 } from "../actions/retreat"
@@ -184,30 +189,10 @@ export default function retreatReducer(
       return state
     case GET_WEBSITE_SUCCESS:
     case PATCH_WEBSITE_SUCCESS:
-    case POST_WEBSITE_SUCCESS:
+    case POST_INITIAL_WEBSITE_SUCCESS:
       payload = (action as ApiAction)
         .payload as AttendeeLandingWebsiteApiResponse
-      return {
-        ...state,
-        websites: {
-          ...state.websites,
-          [payload.website.id]: payload.website,
-        },
-        retreats: {
-          ...state.retreats,
-          ...(state.retreats[payload.website.retreat_id] &&
-          state.retreats[payload.website.retreat_id] !== ResourceNotFound
-            ? {
-                [payload.website.retreat_id]: {
-                  ...(state.retreats[
-                    payload.website.retreat_id
-                  ] as RetreatModel),
-                  attendees_website_id: payload.website.id,
-                },
-              }
-            : {}),
-        },
-      }
+      return reduceWebsitePost(payload, state)
     case GET_PAGE_SUCCESS:
     case PATCH_PAGE_SUCCESS:
       payload = (action as ApiAction)
@@ -227,41 +212,11 @@ export default function retreatReducer(
     case POST_BLOCK_SUCCESS:
       payload = (action as ApiAction)
         .payload as AttendeeLandingWebsitePageBlockApiResponse
-      return {
-        ...state,
-        blocks: {...state.blocks, [payload.block.id]: payload.block},
-        pages: {
-          ...state.pages,
-          [payload.block.page_id]: {
-            ...state.pages[payload.block.page_id]!,
-            block_ids: [
-              ...(state.pages[payload.block.page_id]
-                ? state.pages[payload.block.page_id]!.block_ids
-                : []),
-              payload.block.id,
-            ],
-          },
-        },
-      }
+      return reduceBlockPost(payload, state)
     case POST_PAGE_SUCCESS:
       payload = (action as ApiAction)
         .payload as AttendeeLandingWebsitePageApiResponse
-      return {
-        ...state,
-        pages: {...state.pages, [payload.page.id]: payload.page},
-        websites: {
-          ...state.websites,
-          [payload.page.website_id]: {
-            ...state.websites[payload.page.website_id]!,
-            page_ids: [
-              ...(state.websites[payload.page.website_id]
-                ? state.websites[payload.page.website_id]!.page_ids
-                : []),
-              payload.page.id,
-            ],
-          },
-        },
-      }
+      return reducePagePost(payload, state)
     case DELETE_PAGE_SUCCESS:
       const pageId = (action as unknown as {meta: {pageId: number}}).meta.pageId
       let websiteId = Object.values(state.websites).find((website) =>


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-

##### Description
Website Page Names with spaces now use dashes for link,
Register Now link now is tied to the button in the top right of the attendee landing website **( If possible I would like you to review how this works, I'll make a comment in the code, because it currently works, but it is somewhat complicated due to the fact that initially we didn't have the retreat information in the store while on the website) **
Double posting of home is now fixed and a template is initially populated in the home page, using a website initialize route
##### Demo
