### PR TITLE
changed verbiage for trip length drop down and budget subtabs

### DIFF
--- a/modules/flok/src/components/budget/BudgetCalculator.tsx
+++ b/modules/flok/src/components/budget/BudgetCalculator.tsx
@@ -152,7 +152,7 @@ export default function BudgetCalculator(props: {
               }}>
               {[3, 4, 5, 6, 7, 8].map((d) => (
                 <MenuItem key={d} value={d}>
-                  {d} days
+                  {d} days / {d - 1} nights
                 </MenuItem>
               ))}
             </TextField>

--- a/modules/flok/src/components/page/PageSidenav.tsx
+++ b/modules/flok/src/components/page/PageSidenav.tsx
@@ -145,12 +145,12 @@ let navItems: NavItem[] = [
     redirect: redirectFlok("RetreatBudgetPage"),
     navSubItems: [
       {
-        title: "Calculator",
+        title: "Estimate",
         activeRoutes: ["RetreatBudgetEstimatePage"],
         redirect: redirectFlok("RetreatBudgetEstimatePage"),
       },
       {
-        title: "Details",
+        title: "Actual",
         activeRoutes: [],
         redirect: (retreat) =>
           retreat.budget_link


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-329
https://linear.app/flok/issue/FLO-330

##### Description
changed verbiage for trip length drop down and budget sub-tabs
##### Demo
<img width="1512" alt="Screen Shot 2022-05-18 at 11 24 12 AM" src="https://user-images.githubusercontent.com/41205015/169081677-8d67fe85-4f6c-4926-951d-849ab2b7ad19.png">

