### PR TITLE
doesn't show budget breakdown until calculate is clicked

### DIFF
--- a/modules/flok/src/pages/dashboard/BudgetEstimatePage.tsx
+++ b/modules/flok/src/pages/dashboard/BudgetEstimatePage.tsx
@@ -1,4 +1,5 @@
 import {makeStyles} from "@material-ui/core"
+import _ from "lodash"
 import {useState} from "react"
 import {withRouter} from "react-router-dom"
 import AppTypography from "../../components/base/AppTypography"
@@ -6,8 +7,8 @@ import BudgetBreakdownView from "../../components/budget/BudgetBreakdownView"
 import BudgetCalculator from "../../components/budget/BudgetCalculator"
 import PageBody from "../../components/page/PageBody"
 import {
-  BUDGET_TOOL_FLOK_RECOMENDATIONS,
   getBudgetBreakdown,
+  INITIAL_BUDGET_TOOL_VALUES,
 } from "../../utils/budgetUtils"
 
 let useStyles = makeStyles((theme) => ({
@@ -27,7 +28,7 @@ type BudgetEstimatePageProps = {}
 
 function BudgetEstimatePage(props: BudgetEstimatePageProps) {
   let classes = useStyles()
-  let [userInput, setUserInput] = useState(BUDGET_TOOL_FLOK_RECOMENDATIONS)
+  let [userInput, setUserInput] = useState(INITIAL_BUDGET_TOOL_VALUES)
   let [breakdown, setBreakdown] = useState(getBudgetBreakdown(userInput))
   return (
     <PageBody appBar>
@@ -41,7 +42,12 @@ function BudgetEstimatePage(props: BudgetEstimatePageProps) {
             setBreakdown(getBudgetBreakdown(vals))
           }}
         />
-        <BudgetBreakdownView breakdown={breakdown} breakdownInput={userInput} />
+        {!_.isEqual(userInput, INITIAL_BUDGET_TOOL_VALUES) && (
+          <BudgetBreakdownView
+            breakdown={breakdown}
+            breakdownInput={userInput}
+          />
+        )}
       </div>
     </PageBody>
   )

--- a/modules/flok/src/utils/budgetUtils.tsx
+++ b/modules/flok/src/utils/budgetUtils.tsx
@@ -9,7 +9,7 @@ export type BudgetBreakdownInputType = {
   addons: string[]
 }
 
-export const BUDGET_TOOL_FLOK_RECOMENDATIONS = {
+export const BUDGET_TOOL_FLOK_RECOMENDATIONS: BudgetBreakdownInputType = {
   trip_length: 4,
   experience_type: 4,
   avg_flight_cost: 600,
@@ -23,9 +23,9 @@ export const BUDGET_TOOL_FLOK_RECOMENDATIONS = {
     "Airport to home",
   ],
   addons: ["COVID test", "Swag", "Photographer", "Onsite Coordinator"],
-} as BudgetBreakdownInputType
+}
 
-export const INITIAL_BUDGET_TOOL_VALUES = {
+export const INITIAL_BUDGET_TOOL_VALUES: BudgetBreakdownInputType = {
   trip_length: 1,
   experience_type: 0,
   avg_flight_cost: 0,
@@ -34,7 +34,7 @@ export const INITIAL_BUDGET_TOOL_VALUES = {
   alcohol: "No",
   ground_transportation: [],
   addons: [],
-} as BudgetBreakdownInputType
+}
 
 export type BudgetBreakdownType = {
   attendeeCost: number

--- a/modules/flok/src/utils/budgetUtils.tsx
+++ b/modules/flok/src/utils/budgetUtils.tsx
@@ -26,15 +26,15 @@ export const BUDGET_TOOL_FLOK_RECOMENDATIONS = {
 } as BudgetBreakdownInputType
 
 export const INITIAL_BUDGET_TOOL_VALUES = {
-  trip_length: 0,
+  trip_length: 1,
   experience_type: 0,
-  avg_flight_cost: 600,
-  num_attendees: null,
-  work_play_mix: "",
-  alcohol: "",
+  avg_flight_cost: 0,
+  num_attendees: 0,
+  work_play_mix: "Mix",
+  alcohol: "No",
   ground_transportation: [],
   addons: [],
-}
+} as BudgetBreakdownInputType
 
 export type BudgetBreakdownType = {
   attendeeCost: number


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-348

##### Description

Doesn't show budget breakdown until calculate is clicked initially

##### Demo
<img width="1512" alt="Screen Shot 2022-05-25 at 12 42 19 PM" src="https://user-images.githubusercontent.com/41205015/170316384-fcd833ff-e5c0-443a-a580-8f59260a9e6d.png">
<img width="1512" alt="Screen Shot 2022-05-25 at 12 42 25 PM" src="https://user-images.githubusercontent.com/41205015/170316397-8aaeedfd-7e86-46b8-a972-a2ffbb3a1c95.png">

