### PR TITLE
Andrew/show signed contract button fix

### DIFF
--- a/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
+++ b/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
@@ -36,6 +36,7 @@ let useStyles = makeStyles((theme) => ({
       justifyContent: "center",
     },
     height: "100%",
+    minHeight: 0,
   },
   hotelDetailsSection: {
     boxShadow: theme.shadows[0],
@@ -67,7 +68,7 @@ let useStyles = makeStyles((theme) => ({
     width: "100%",
     paddingLeft: theme.spacing(0.5),
     "& > .MuiTypography-body1": {
-      whiteSpace: "pre-wrap",
+      whiteSpace: "auto",
     },
     "& > :nth-child(2)": {
       marginLeft: theme.spacing(1),

--- a/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
+++ b/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
@@ -68,7 +68,7 @@ let useStyles = makeStyles((theme) => ({
     width: "100%",
     paddingLeft: theme.spacing(0.5),
     "& > .MuiTypography-body1": {
-      whiteSpace: "auto",
+      whiteSpace: "pre-wrap",
     },
     "& > :nth-child(2)": {
       marginLeft: theme.spacing(1),


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-

##### Description
adds minheight: 0 to ensure the view signed contract button is shown when notes are long

##### Demo
<img width="1512" alt="Screen Shot 2022-05-25 at 5 08 30 PM" src="https://user-images.githubusercontent.com/41205015/170367639-0f5f3338-c209-46c5-951c-d97da6025e64.png">
