### PR TITLE
switched order of signed contract notes and view contract button in t…

### DIFF
--- a/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
+++ b/modules/flok/src/components/lodging/RetreatHotelPageBody.tsx
@@ -169,18 +169,6 @@ export default function RetreatHotelPageBody(props: RetreatHotelPageBodyProps) {
                     </Typography>
                   </div>
                 ) : undefined}
-                {retreat.lodging_final_contract_notes ? (
-                  <div className={classes.hotelDetail}>
-                    <Typography variant="body2">
-                      <strong>Contract notes</strong>
-                    </Typography>
-                    <Typography
-                      variant="body1"
-                      dangerouslySetInnerHTML={{
-                        __html: retreat.lodging_final_contract_notes,
-                      }}></Typography>
-                  </div>
-                ) : undefined}
                 {retreat.lodging_final_contract_url ? (
                   <div className={classes.hotelDetail}>
                     <Typography variant="body2">
@@ -194,6 +182,18 @@ export default function RetreatHotelPageBody(props: RetreatHotelPageBodyProps) {
                       target="_blank">
                       View
                     </Button>
+                  </div>
+                ) : undefined}
+                {retreat.lodging_final_contract_notes ? (
+                  <div className={classes.hotelDetail}>
+                    <Typography variant="body2">
+                      <strong>Contract notes</strong>
+                    </Typography>
+                    <Typography
+                      variant="body1"
+                      dangerouslySetInnerHTML={{
+                        __html: retreat.lodging_final_contract_notes,
+                      }}></Typography>
                   </div>
                 ) : undefined}
               </Paper>


### PR DESCRIPTION
…he lodging tab

#### Linear 🎫 
https://linear.app/flok/issue/FLO-

##### Description
notes now under signed contract link in lodging tab
##### Demo
<img width="1512" alt="Screen Shot 2022-06-06 at 11 17 02 AM" src="https://user-images.githubusercontent.com/41205015/172191082-0ac6e106-3b65-436d-8774-40fd985e24ed.png">
