### PR TITLE
chips for registration status

### DIFF
--- a/modules/flok/src/pages/dashboard/AttendeesPage.tsx
+++ b/modules/flok/src/pages/dashboard/AttendeesPage.tsx
@@ -146,6 +146,11 @@ let useStyles = makeStyles((theme) => ({
     color: theme.palette.error.main,
     height: "25px",
   },
+  successChip: {
+    borderColor: theme.palette.success.main,
+    color: theme.palette.success.main,
+    height: "25px",
+  },
 }))
 
 function AttendeesPage() {
@@ -379,6 +384,29 @@ function AttendeesPage() {
               ),
             },
             {
+              name: "Registration Status",
+              colId: "info_status",
+              renderCell: (val) => {
+                if (val === "INFO_ENTERED") {
+                  return (
+                    <Chip
+                      variant="outlined"
+                      label={"Registered"}
+                      className={classes.successChip}
+                    />
+                  )
+                } else if (val === "CREATED") {
+                  return (
+                    <Chip
+                      variant="outlined"
+                      label={"Incomplete"}
+                      className={classes.warningChip}
+                    />
+                  )
+                } else return <></>
+              },
+            },
+            {
               name: "",
               colId: "notes",
               renderCell: (val) => {
@@ -426,9 +454,6 @@ function AttendeesPage() {
                   .map((info: RetreatAttendeeModel) => ({
                     id: info.id,
                     disabled: !info.info_status.endsWith("INFO_ENTERED"),
-                    tooltip: !info.info_status.endsWith("INFO_ENTERED")
-                      ? "Once the attendee fills out the registration form you will be able to view more of their information here."
-                      : "",
                     item: info,
                   }))
               : []


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-362

##### Description
Now has chips to show registration status for the attendees list page.  Wasn't quite sure what wording you wanted, lmk if you want it changed


##### Demo

<img width="1512" alt="Screen Shot 2022-07-01 at 11 13 54 AM" src="https://user-images.githubusercontent.com/41205015/176922275-bc0841b0-2b9e-4318-be59-064550495573.png">
