### PR TITLE
changed retreaat landing page to work off of idx rather than id

### DIFF
--- a/modules/flok/src/Stack.tsx
+++ b/modules/flok/src/Stack.tsx
@@ -76,15 +76,16 @@ export class AppRoutes {
 
     // AttendeelLanding page
     LandingPageGeneratorHome: "/r/:retreatIdx/attendees/landing",
-    LandingPageGeneratorPage: "/r/:retreatIdx/attendees/landing/:currentPageId",
+    LandingPageGeneratorPage:
+      "/r/:retreatIdx/attendees/landing/:currentPageIdx",
     LandingPageGeneratorConfig:
-      "/r/:retreatIdx/attendees/landing/:currentPageId/config",
+      "/r/:retreatIdx/attendees/landing/:currentPageIdx/config",
     LandingPageGeneratorConfigWebsiteSettings:
-      "/r/:retreatIdx/attendees/landing/:currentPageId/config/website-settings",
+      "/r/:retreatIdx/attendees/landing/:currentPageIdx/config/website-settings",
     LandingPageGeneratorConfigPageSettings:
-      "/r/:retreatIdx/attendees/landing/:currentPageId/config/page-settings/:pageId",
+      "/r/:retreatIdx/attendees/landing/:currentPageIdx/config/page-settings/:pageIdx",
     LandingPageGeneratorConfigAddPage:
-      "/r/:retreatIdx/attendees/landing/:currentPageId/config/add-page",
+      "/r/:retreatIdx/attendees/landing/:currentPageIdx/config/add-page",
 
     RetreatFlightsPage: "/r/:retreatIdx/flights",
 

--- a/modules/flok/src/components/attendee-site/AddPageForm.tsx
+++ b/modules/flok/src/components/attendee-site/AddPageForm.tsx
@@ -20,6 +20,7 @@ let useStyles = makeStyles((theme) => ({
 type AddPageFormProps = {
   websiteId: number
   retreatIdx: number
+  websitePageIds: number[]
 }
 function AddPageForm(props: AddPageFormProps) {
   let classes = useStyles()
@@ -33,7 +34,7 @@ function AddPageForm(props: AddPageFormProps) {
         push(
           AppRoutes.getPath("LandingPageGeneratorPage", {
             retreatIdx: props.retreatIdx.toString(),
-            currentPageId: result.payload.page.id,
+            currentPageIdx: props.websitePageIds.length.toString(),
           })
         )
       )

--- a/modules/flok/src/components/attendee-site/EditPageForm.tsx
+++ b/modules/flok/src/components/attendee-site/EditPageForm.tsx
@@ -28,7 +28,7 @@ let useStyles = makeStyles((theme) => ({
 type EditPageFormProps = {
   pageId: number
   retreatIdx: string
-  currentPageId: string
+  currentPageIdx: string
 }
 
 function EditPageForm(props: EditPageFormProps) {
@@ -47,7 +47,7 @@ function EditPageForm(props: EditPageFormProps) {
         push(
           AppRoutes.getPath("LandingPageGeneratorConfig", {
             retreatIdx: props.retreatIdx.toString(),
-            currentPageId: props.currentPageId,
+            currentPageIdx: props.currentPageIdx,
           })
         )
       )

--- a/modules/flok/src/components/attendee-site/EditWebsiteForm.tsx
+++ b/modules/flok/src/components/attendee-site/EditWebsiteForm.tsx
@@ -43,7 +43,7 @@ let useStyles = makeStyles((theme) => ({
 type EditWebsiteFormProps = {
   websiteId: number
   retreatIdx: number
-  currentPageId: string
+  currentPageIdx: string
   isLive: boolean
 }
 function EditWebsiteForm(props: EditWebsiteFormProps) {
@@ -70,7 +70,7 @@ function EditWebsiteForm(props: EditWebsiteFormProps) {
         push(
           AppRoutes.getPath("LandingPageGeneratorConfig", {
             retreatIdx: props.retreatIdx.toString(),
-            currentPageId: props.currentPageId,
+            currentPageIdx: props.currentPageIdx,
           })
         )
       )

--- a/modules/flok/src/components/attendee-site/LandingPageEditForm.tsx
+++ b/modules/flok/src/components/attendee-site/LandingPageEditForm.tsx
@@ -6,12 +6,13 @@ import {useAttendeeLandingPage} from "../../utils/retreatUtils"
 import WYSIWYGBlockEditor from "./WYSIWYGBlockEditor"
 
 type LandingPageEditFormProps = {
-  pageId: number
+  pageIdx: number
   config: boolean
+  websitePageIds: number[]
 }
 
 function LandingPageEditForm(props: LandingPageEditFormProps) {
-  let page = useAttendeeLandingPage(props.pageId)
+  let page = useAttendeeLandingPage(props.pageIdx)
   let dispatch = useDispatch()
 
   if (!page) {
@@ -27,7 +28,7 @@ function LandingPageEditForm(props: LandingPageEditFormProps) {
           onClick={() =>
             dispatch(
               postBlock({
-                page_id: props.pageId,
+                page_id: props.websitePageIds[props.pageIdx],
                 type: "WYSIWYG",
               })
             )

--- a/modules/flok/src/components/attendee-site/LandingPageGeneratorNavTool.tsx
+++ b/modules/flok/src/components/attendee-site/LandingPageGeneratorNavTool.tsx
@@ -43,6 +43,7 @@ type LandingPageGeneratorNavToolProps = {
   retreatIdx: number
   selectedPage: AttendeeLandingWebsitePageModel
   website: AttendeeLandingWebsiteModel
+  selectedPageIdx: number
 }
 
 function LandingPageGeneratorNavTool(props: LandingPageGeneratorNavToolProps) {
@@ -57,12 +58,13 @@ function LandingPageGeneratorNavTool(props: LandingPageGeneratorNavToolProps) {
       <div className={classes.tabsAndControlsDiv}>
         <div className={classes.tabsDiv}>
           {!isSmallScreen ? (
-            props.pageIds.map((pageId) => (
+            props.pageIds.map((pageId, index) => (
               <div className={classes.tab}>
                 <LandingPageGeneratorTab
                   selected={pageId === props.selectedPage.id}
                   retreatIdx={props.retreatIdx}
-                  pageId={pageId}
+                  pageIdx={index}
+                  pageIds={props.pageIds}
                 />
               </div>
             ))
@@ -70,8 +72,9 @@ function LandingPageGeneratorNavTool(props: LandingPageGeneratorNavToolProps) {
             <div className={classes.tab}>
               <LandingPageGeneratorTab
                 selected={true}
+                pageIds={props.pageIds}
                 retreatIdx={props.retreatIdx}
-                pageId={props.selectedPage.id}
+                pageIdx={props.selectedPageIdx}
               />
             </div>
           )}
@@ -82,7 +85,7 @@ function LandingPageGeneratorNavTool(props: LandingPageGeneratorNavToolProps) {
               push(
                 AppRoutes.getPath("LandingPageGeneratorConfigAddPage", {
                   retreatIdx: props.retreatIdx.toString(),
-                  currentPageId: props.selectedPage.id.toString(),
+                  currentPageIdx: props.selectedPageIdx.toString(),
                 })
               )
             )
@@ -95,7 +98,7 @@ function LandingPageGeneratorNavTool(props: LandingPageGeneratorNavToolProps) {
               push(
                 AppRoutes.getPath("LandingPageGeneratorConfig", {
                   retreatIdx: props.retreatIdx.toString(),
-                  currentPageId: props.selectedPage.id.toString(),
+                  currentPageIdx: props.selectedPageIdx.toString(),
                 })
               )
             )

--- a/modules/flok/src/components/attendee-site/LandingPageGeneratorTab.tsx
+++ b/modules/flok/src/components/attendee-site/LandingPageGeneratorTab.tsx
@@ -16,13 +16,14 @@ let useStyles = makeStyles((theme) => ({
 }))
 
 type LandingPageGeneratorTabProps = {
-  pageId: number
+  pageIdx: number
   retreatIdx: number
   selected: boolean
+  pageIds: number[]
 }
 
 function LandingPageGeneratorTab(props: LandingPageGeneratorTabProps) {
-  let page = useAttendeeLandingPage(props.pageId)
+  let page = useAttendeeLandingPage(props.pageIds[props.pageIdx])
   let classes = useStyles()
 
   return (
@@ -31,7 +32,7 @@ function LandingPageGeneratorTab(props: LandingPageGeneratorTabProps) {
       className={classes.link}
       to={AppRoutes.getPath("LandingPageGeneratorPage", {
         retreatIdx: props.retreatIdx.toString(),
-        currentPageId: props.pageId.toString(),
+        currentPageIdx: props.pageIdx.toString(),
       })}>
       <AppTypography
         className={classes.tabText}

--- a/modules/flok/src/components/attendee-site/PageWebsiteLink.tsx
+++ b/modules/flok/src/components/attendee-site/PageWebsiteLink.tsx
@@ -23,15 +23,18 @@ let useStyles = makeStyles((theme) => ({
   },
 }))
 type PageWebsiteLinkProps = {
-  pageId: number
+  pageIdx: number
   retreatIdx: number
-  currentPageId: string
+  currentPageIdx: string
+  websitePageIds: number[] | undefined
 }
 
 function PageWebsiteLink(props: PageWebsiteLinkProps) {
   let classes = useStyles()
   let dispatch = useDispatch()
-  let page = useAttendeeLandingPage(props.pageId)
+  let page = useAttendeeLandingPage(
+    props.websitePageIds ? props.websitePageIds[props.pageIdx] : -1
+  )
   return (
     <div className={classes.pageNav}>
       <Link
@@ -39,7 +42,7 @@ function PageWebsiteLink(props: PageWebsiteLinkProps) {
         component={RouterLink}
         to={AppRoutes.getPath("LandingPageGeneratorPage", {
           retreatIdx: props.retreatIdx.toString(),
-          currentPageId: props.pageId.toString(),
+          currentPageIdx: props.pageIdx.toString(),
         })}>
         <Typography>{page?.title}</Typography>
       </Link>
@@ -49,8 +52,8 @@ function PageWebsiteLink(props: PageWebsiteLinkProps) {
             push(
               AppRoutes.getPath("LandingPageGeneratorConfigPageSettings", {
                 retreatIdx: props.retreatIdx.toString(),
-                currentPageId: props.currentPageId,
-                pageId: props.pageId.toString(),
+                currentPageIdx: props.currentPageIdx,
+                pageIdx: props.pageIdx.toString(),
               })
             )
           )

--- a/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
+++ b/modules/flok/src/components/lodging/ProposalsListPageBody.tsx
@@ -73,7 +73,6 @@ export default function ProposalsListPageBody(
         hotel.state !== "PENDING"
       ) {
         setShowOld(false)
-        console.log(hotel)
         break
       }
     }

--- a/modules/flok/src/pages/dashboard/CreateRetreatWebsite.tsx
+++ b/modules/flok/src/pages/dashboard/CreateRetreatWebsite.tsx
@@ -73,7 +73,7 @@ function CreateRetreatWebsite() {
         push(
           AppRoutes.getPath("LandingPageGeneratorPage", {
             retreatIdx: retreatIdx.toString(),
-            currentPageId: websiteResponse.payload.website.page_ids[0],
+            currentPageIdx: "0",
           })
         )
       )


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-386

##### Description
Updates landing page generator to work using page idx rather than page id.  Also removes logs that I left in accidentally before
##### Demo
