### PR TITLE
removed flex from details on proposal page so that it is now full width

### DIFF
--- a/modules/flok/src/pages/dashboard/LodgingProposalPage.tsx
+++ b/modules/flok/src/pages/dashboard/LodgingProposalPage.tsx
@@ -75,9 +75,6 @@ let useStyles = makeStyles((theme) => ({
     },
   },
   details: {
-    display: "flex",
-    flexDirection: "row",
-    flexWrap: "wrap",
     marginLeft: -theme.spacing(2),
     marginTop: -theme.spacing(2),
     "& > $detailsSection": {


### PR DESCRIPTION
#### Linear 🎫 
https://linear.app/flok/issue/FLO-

##### Description
Proposals now are full width regardless of if their content stretches full width

##### Demo
With change: 
<img width="1512" alt="Marriott Montréal Chäteau" src="https://user-images.githubusercontent.com/41205015/189975469-dce9b24d-2a64-4012-9a83-460b7a0f32a1.png">
Before:
<img width="1512" alt="Marriott Montréal Chäteau" src="https://user-images.githubusercontent.com/41205015/189975507-cc3f894d-5d71-4734-9431-1c8ae848296d.png">

